### PR TITLE
Add namespace and path-specific routing for invoker

### DIFF
--- a/deploy/httproute-invoker-dev.yaml
+++ b/deploy/httproute-invoker-dev.yaml
@@ -16,13 +16,24 @@ spec:
         value: "/ws"
     backendRefs:
     - name: invoker-server-svc
+      namespace: invoker-dev
       port: 8001
       weight: 1
   - matches:
     - path:
         type: PathPrefix
-        value: "/"
+        value: "/sessions"
     backendRefs:
     - name: invoker-server-svc
+      namespace: invoker-dev
+      port: 8000
+      weight: 1
+  - matches:
+    - path:
+        type: PathPrefix
+        value: "/v1"
+    backendRefs:
+    - name: invoker-server-svc
+      namespace: invoker-dev
       port: 8000
       weight: 1


### PR DESCRIPTION
- Add namespace 'invoker-dev' to all backend references
- Split root path routing into specific paths:
  - /sessions -> port 8000
  - /v1 -> port 8000
- Keep WebSocket routing (/ws) on port 8001

This provides more granular control over HTTP routing patterns and ensures proper namespace isolation for the invoker service.