### PR TITLE
feat: add ExportPromoCodes API

### DIFF
--- a/backoffice/service/v1/backoffice_wallet.pb.go
+++ b/backoffice/service/v1/backoffice_wallet.pb.go
@@ -4606,8 +4606,8 @@ func (x *ListUniversalCodeUsagesRequest) GetCampaignId() int64 {
 	return 0
 }
 
-// Export Promo Code Campaign
-type ExportPromoCodeCampaignRequest struct {
+// Export Promo Codes
+type ExportPromoCodesRequest struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	CampaignId int64                  `protobuf:"varint,1,opt,name=campaign_id,json=campaignId,proto3" json:"campaign_id,omitempty"`
 	// "csv", "excel", or "pdf"
@@ -4622,20 +4622,20 @@ type ExportPromoCodeCampaignRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ExportPromoCodeCampaignRequest) Reset() {
-	*x = ExportPromoCodeCampaignRequest{}
+func (x *ExportPromoCodesRequest) Reset() {
+	*x = ExportPromoCodesRequest{}
 	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ExportPromoCodeCampaignRequest) String() string {
+func (x *ExportPromoCodesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ExportPromoCodeCampaignRequest) ProtoMessage() {}
+func (*ExportPromoCodesRequest) ProtoMessage() {}
 
-func (x *ExportPromoCodeCampaignRequest) ProtoReflect() protoreflect.Message {
+func (x *ExportPromoCodesRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -4647,47 +4647,47 @@ func (x *ExportPromoCodeCampaignRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ExportPromoCodeCampaignRequest.ProtoReflect.Descriptor instead.
-func (*ExportPromoCodeCampaignRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use ExportPromoCodesRequest.ProtoReflect.Descriptor instead.
+func (*ExportPromoCodesRequest) Descriptor() ([]byte, []int) {
 	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{62}
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetCampaignId() int64 {
+func (x *ExportPromoCodesRequest) GetCampaignId() int64 {
 	if x != nil {
 		return x.CampaignId
 	}
 	return 0
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetFormat() string {
+func (x *ExportPromoCodesRequest) GetFormat() string {
 	if x != nil {
 		return x.Format
 	}
 	return ""
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetTimeZone() string {
+func (x *ExportPromoCodesRequest) GetTimeZone() string {
 	if x != nil {
 		return x.TimeZone
 	}
 	return ""
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetUserId() int64 {
+func (x *ExportPromoCodesRequest) GetUserId() int64 {
 	if x != nil && x.UserId != nil {
 		return *x.UserId
 	}
 	return 0
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetStatus() string {
+func (x *ExportPromoCodesRequest) GetStatus() string {
 	if x != nil && x.Status != nil {
 		return *x.Status
 	}
 	return ""
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetCode() string {
+func (x *ExportPromoCodesRequest) GetCode() string {
 	if x != nil && x.Code != nil {
 		return *x.Code
 	}
@@ -5969,8 +5969,8 @@ const file_backoffice_service_v1_backoffice_wallet_proto_rawDesc = "" +
 	"\x05codes\x18\x02 \x03(\tR\x05codes\"A\n" +
 	"\x1eListUniversalCodeUsagesRequest\x12\x1f\n" +
 	"\vcampaign_id\x18\x01 \x01(\x03R\n" +
-	"campaignId\"\xea\x01\n" +
-	"\x1eExportPromoCodeCampaignRequest\x12\x1f\n" +
+	"campaignId\"\xe3\x01\n" +
+	"\x17ExportPromoCodesRequest\x12\x1f\n" +
 	"\vcampaign_id\x18\x01 \x01(\x03R\n" +
 	"campaignId\x12\x16\n" +
 	"\x06format\x18\x02 \x01(\tR\x06format\x12\x1b\n" +
@@ -6021,7 +6021,7 @@ const file_backoffice_service_v1_backoffice_wallet_proto_rawDesc = "" +
 	"\x0e_expiring_soonB\a\n" +
 	"\x05_pageB\f\n" +
 	"\n" +
-	"_page_size2\xbaS\n" +
+	"_page_size2\xa5S\n" +
 	"\x10BackofficeWallet\x12\x8b\x01\n" +
 	"\n" +
 	"GetWallets\x12,.api.backoffice.service.v1.GetWalletsRequest\x1a).api.wallet.service.v1.GetWalletsResponse\"$\x82\xd3\xe4\x93\x02\x1e:\x01*\"\x19/v1/backoffice/wallet/get\x12\xa9\x01\n" +
@@ -6056,8 +6056,8 @@ const file_backoffice_service_v1_backoffice_wallet_proto_rawDesc = "" +
 	"\x1cListPromoCodeCampaignDetails\x12>.api.backoffice.service.v1.ListPromoCodeCampaignDetailsRequest\x1a;.api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse\"<\x82\xd3\xe4\x93\x026:\x01*\"1/v1/backoffice/wallet/promo-code/campaign/details\x12\xd7\x01\n" +
 	"\x19GenerateOneTimePromoCodes\x12;.api.backoffice.service.v1.GenerateOneTimePromoCodesRequest\x1a8.api.wallet.service.v1.GenerateOneTimePromoCodesResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/backoffice/wallet/promo-code/one-time/codes/generate\x12\xde\x01\n" +
 	"\x1bGenerateUniversalPromoCodes\x12=.api.backoffice.service.v1.GenerateUniversalPromoCodesRequest\x1a:.api.wallet.service.v1.GenerateUniversalPromoCodesResponse\"D\x82\xd3\xe4\x93\x02>:\x01*\"9/v1/backoffice/wallet/promo-code/universal/codes/generate\x12\xcf\x01\n" +
-	"\x17ListUniversalCodeUsages\x129.api.backoffice.service.v1.ListUniversalCodeUsagesRequest\x1a6.api.wallet.service.v1.ListUniversalCodeUsagesResponse\"A\x82\xd3\xe4\x93\x02;:\x01*\"6/v1/backoffice/wallet/promo-code/universal/usages/list\x12\xc9\x01\n" +
-	"\x17ExportPromoCodeCampaign\x129.api.backoffice.service.v1.ExportPromoCodeCampaignRequest\x1a6.api.wallet.service.v1.ExportPromoCodeCampaignResponse\";\x82\xd3\xe4\x93\x025:\x01*\"0/v1/backoffice/wallet/promo-code/campaign/export\x12\xd1\x01\n" +
+	"\x17ListUniversalCodeUsages\x129.api.backoffice.service.v1.ListUniversalCodeUsagesRequest\x1a6.api.wallet.service.v1.ListUniversalCodeUsagesResponse\"A\x82\xd3\xe4\x93\x02;:\x01*\"6/v1/backoffice/wallet/promo-code/universal/usages/list\x12\xb4\x01\n" +
+	"\x10ExportPromoCodes\x122.api.backoffice.service.v1.ExportPromoCodesRequest\x1a/.api.wallet.service.v1.ExportPromoCodesResponse\";\x82\xd3\xe4\x93\x025:\x01*\"0/v1/backoffice/wallet/promo-code/campaign/export\x12\xd1\x01\n" +
 	"\x1dGetGamificationCurrencyConfig\x12?.api.backoffice.service.v1.GetGamificationCurrencyConfigRequest\x1a<.api.wallet.service.v1.GetGamificationCurrencyConfigResponse\"1\x82\xd3\xe4\x93\x02+:\x01*\"&/v1/backoffice/wallet/gamification/get\x12\xd4\x01\n" +
 	"\x1cUpdateOperatorCurrencyConfig\x12>.api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest\x1a;.api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse\"7\x82\xd3\xe4\x93\x021:\x01*\",/v1/backoffice/wallet/currency/config/update\x12\xad\x01\n" +
 	"\x12UpdateWalletConfig\x124.api.backoffice.service.v1.UpdateWalletConfigRequest\x1a1.api.wallet.service.v1.UpdateWalletConfigResponse\".\x82\xd3\xe4\x93\x02(:\x01*\"#/v1/backoffice/wallet/config/update\x12\xf5\x01\n" +
@@ -6155,7 +6155,7 @@ var file_backoffice_service_v1_backoffice_wallet_proto_goTypes = []any{
 	(*GenerateOneTimePromoCodesRequest)(nil),                         // 59: api.backoffice.service.v1.GenerateOneTimePromoCodesRequest
 	(*GenerateUniversalPromoCodesRequest)(nil),                       // 60: api.backoffice.service.v1.GenerateUniversalPromoCodesRequest
 	(*ListUniversalCodeUsagesRequest)(nil),                           // 61: api.backoffice.service.v1.ListUniversalCodeUsagesRequest
-	(*ExportPromoCodeCampaignRequest)(nil),                           // 62: api.backoffice.service.v1.ExportPromoCodeCampaignRequest
+	(*ExportPromoCodesRequest)(nil),                                  // 62: api.backoffice.service.v1.ExportPromoCodesRequest
 	(*ManualAdjustCreditTurnoverFieldRequest)(nil),                   // 63: api.backoffice.service.v1.ManualAdjustCreditTurnoverFieldRequest
 	(*SetAppDownloadRewardConfigRequest)(nil),                        // 64: api.backoffice.service.v1.SetAppDownloadRewardConfigRequest
 	(*GetAppDownloadRewardConfigRequest)(nil),                        // 65: api.backoffice.service.v1.GetAppDownloadRewardConfigRequest
@@ -6196,7 +6196,7 @@ var file_backoffice_service_v1_backoffice_wallet_proto_goTypes = []any{
 	(*v1.GenerateOneTimePromoCodesResponse)(nil),       // 100: api.wallet.service.v1.GenerateOneTimePromoCodesResponse
 	(*v1.GenerateUniversalPromoCodesResponse)(nil),     // 101: api.wallet.service.v1.GenerateUniversalPromoCodesResponse
 	(*v1.ListUniversalCodeUsagesResponse)(nil),         // 102: api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	(*v1.ExportPromoCodeCampaignResponse)(nil),         // 103: api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	(*v1.ExportPromoCodesResponse)(nil),                // 103: api.wallet.service.v1.ExportPromoCodesResponse
 	(*v1.GetGamificationCurrencyConfigResponse)(nil),   // 104: api.wallet.service.v1.GetGamificationCurrencyConfigResponse
 	(*v1.UpdateOperatorCurrencyConfigResponse)(nil),    // 105: api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse
 	(*v1.UpdateWalletConfigResponse)(nil),              // 106: api.wallet.service.v1.UpdateWalletConfigResponse
@@ -6336,7 +6336,7 @@ var file_backoffice_service_v1_backoffice_wallet_proto_depIdxs = []int32{
 	59,  // 115: api.backoffice.service.v1.BackofficeWallet.GenerateOneTimePromoCodes:input_type -> api.backoffice.service.v1.GenerateOneTimePromoCodesRequest
 	60,  // 116: api.backoffice.service.v1.BackofficeWallet.GenerateUniversalPromoCodes:input_type -> api.backoffice.service.v1.GenerateUniversalPromoCodesRequest
 	61,  // 117: api.backoffice.service.v1.BackofficeWallet.ListUniversalCodeUsages:input_type -> api.backoffice.service.v1.ListUniversalCodeUsagesRequest
-	62,  // 118: api.backoffice.service.v1.BackofficeWallet.ExportPromoCodeCampaign:input_type -> api.backoffice.service.v1.ExportPromoCodeCampaignRequest
+	62,  // 118: api.backoffice.service.v1.BackofficeWallet.ExportPromoCodes:input_type -> api.backoffice.service.v1.ExportPromoCodesRequest
 	39,  // 119: api.backoffice.service.v1.BackofficeWallet.GetGamificationCurrencyConfig:input_type -> api.backoffice.service.v1.GetGamificationCurrencyConfigRequest
 	40,  // 120: api.backoffice.service.v1.BackofficeWallet.UpdateOperatorCurrencyConfig:input_type -> api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest
 	41,  // 121: api.backoffice.service.v1.BackofficeWallet.UpdateWalletConfig:input_type -> api.backoffice.service.v1.UpdateWalletConfigRequest
@@ -6389,7 +6389,7 @@ var file_backoffice_service_v1_backoffice_wallet_proto_depIdxs = []int32{
 	100, // 168: api.backoffice.service.v1.BackofficeWallet.GenerateOneTimePromoCodes:output_type -> api.wallet.service.v1.GenerateOneTimePromoCodesResponse
 	101, // 169: api.backoffice.service.v1.BackofficeWallet.GenerateUniversalPromoCodes:output_type -> api.wallet.service.v1.GenerateUniversalPromoCodesResponse
 	102, // 170: api.backoffice.service.v1.BackofficeWallet.ListUniversalCodeUsages:output_type -> api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	103, // 171: api.backoffice.service.v1.BackofficeWallet.ExportPromoCodeCampaign:output_type -> api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	103, // 171: api.backoffice.service.v1.BackofficeWallet.ExportPromoCodes:output_type -> api.wallet.service.v1.ExportPromoCodesResponse
 	104, // 172: api.backoffice.service.v1.BackofficeWallet.GetGamificationCurrencyConfig:output_type -> api.wallet.service.v1.GetGamificationCurrencyConfigResponse
 	105, // 173: api.backoffice.service.v1.BackofficeWallet.UpdateOperatorCurrencyConfig:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse
 	106, // 174: api.backoffice.service.v1.BackofficeWallet.UpdateWalletConfig:output_type -> api.wallet.service.v1.UpdateWalletConfigResponse

--- a/backoffice/service/v1/backoffice_wallet.pb.go
+++ b/backoffice/service/v1/backoffice_wallet.pb.go
@@ -4606,6 +4606,94 @@ func (x *ListUniversalCodeUsagesRequest) GetCampaignId() int64 {
 	return 0
 }
 
+// Export Promo Code Campaign
+type ExportPromoCodeCampaignRequest struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	CampaignId int64                  `protobuf:"varint,1,opt,name=campaign_id,json=campaignId,proto3" json:"campaign_id,omitempty"`
+	// "csv", "excel", or "pdf"
+	Format string `protobuf:"bytes,2,opt,name=format,proto3" json:"format,omitempty"`
+	// e.g. "UTC+0", "UTC+8"
+	TimeZone string `protobuf:"bytes,3,opt,name=time_zone,json=timeZone,proto3" json:"time_zone,omitempty"`
+	UserId   *int64 `protobuf:"varint,4,opt,name=user_id,json=userId,proto3,oneof" json:"user_id,omitempty"`
+	// "used" or "unused" (one_time only)
+	Status        *string `protobuf:"bytes,5,opt,name=status,proto3,oneof" json:"status,omitempty"`
+	Code          *string `protobuf:"bytes,6,opt,name=code,proto3,oneof" json:"code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExportPromoCodeCampaignRequest) Reset() {
+	*x = ExportPromoCodeCampaignRequest{}
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[62]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExportPromoCodeCampaignRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExportPromoCodeCampaignRequest) ProtoMessage() {}
+
+func (x *ExportPromoCodeCampaignRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[62]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExportPromoCodeCampaignRequest.ProtoReflect.Descriptor instead.
+func (*ExportPromoCodeCampaignRequest) Descriptor() ([]byte, []int) {
+	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{62}
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetCampaignId() int64 {
+	if x != nil {
+		return x.CampaignId
+	}
+	return 0
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetFormat() string {
+	if x != nil {
+		return x.Format
+	}
+	return ""
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetTimeZone() string {
+	if x != nil {
+		return x.TimeZone
+	}
+	return ""
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetUserId() int64 {
+	if x != nil && x.UserId != nil {
+		return *x.UserId
+	}
+	return 0
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetStatus() string {
+	if x != nil && x.Status != nil {
+		return *x.Status
+	}
+	return ""
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetCode() string {
+	if x != nil && x.Code != nil {
+		return *x.Code
+	}
+	return ""
+}
+
 // ManualAdjustCreditTurnoverField adjusts a credit's turnover or threshold value
 type ManualAdjustCreditTurnoverFieldRequest struct {
 	state        protoimpl.MessageState `protogen:"open.v1"`
@@ -4624,7 +4712,7 @@ type ManualAdjustCreditTurnoverFieldRequest struct {
 
 func (x *ManualAdjustCreditTurnoverFieldRequest) Reset() {
 	*x = ManualAdjustCreditTurnoverFieldRequest{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[62]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4636,7 +4724,7 @@ func (x *ManualAdjustCreditTurnoverFieldRequest) String() string {
 func (*ManualAdjustCreditTurnoverFieldRequest) ProtoMessage() {}
 
 func (x *ManualAdjustCreditTurnoverFieldRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[62]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4649,7 +4737,7 @@ func (x *ManualAdjustCreditTurnoverFieldRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use ManualAdjustCreditTurnoverFieldRequest.ProtoReflect.Descriptor instead.
 func (*ManualAdjustCreditTurnoverFieldRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{62}
+	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ManualAdjustCreditTurnoverFieldRequest) GetTargetUserId() int64 {
@@ -4710,7 +4798,7 @@ type SetAppDownloadRewardConfigRequest struct {
 
 func (x *SetAppDownloadRewardConfigRequest) Reset() {
 	*x = SetAppDownloadRewardConfigRequest{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[63]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4722,7 +4810,7 @@ func (x *SetAppDownloadRewardConfigRequest) String() string {
 func (*SetAppDownloadRewardConfigRequest) ProtoMessage() {}
 
 func (x *SetAppDownloadRewardConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[63]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4735,7 +4823,7 @@ func (x *SetAppDownloadRewardConfigRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetAppDownloadRewardConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetAppDownloadRewardConfigRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{63}
+	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *SetAppDownloadRewardConfigRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -4770,7 +4858,7 @@ type GetAppDownloadRewardConfigRequest struct {
 
 func (x *GetAppDownloadRewardConfigRequest) Reset() {
 	*x = GetAppDownloadRewardConfigRequest{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[64]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4782,7 +4870,7 @@ func (x *GetAppDownloadRewardConfigRequest) String() string {
 func (*GetAppDownloadRewardConfigRequest) ProtoMessage() {}
 
 func (x *GetAppDownloadRewardConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[64]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4795,7 +4883,7 @@ func (x *GetAppDownloadRewardConfigRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetAppDownloadRewardConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetAppDownloadRewardConfigRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{64}
+	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetAppDownloadRewardConfigRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -4822,7 +4910,7 @@ type ListOperatorWithdrawableAmountsRequest struct {
 
 func (x *ListOperatorWithdrawableAmountsRequest) Reset() {
 	*x = ListOperatorWithdrawableAmountsRequest{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[65]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4834,7 +4922,7 @@ func (x *ListOperatorWithdrawableAmountsRequest) String() string {
 func (*ListOperatorWithdrawableAmountsRequest) ProtoMessage() {}
 
 func (x *ListOperatorWithdrawableAmountsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[65]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4847,7 +4935,7 @@ func (x *ListOperatorWithdrawableAmountsRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use ListOperatorWithdrawableAmountsRequest.ProtoReflect.Descriptor instead.
 func (*ListOperatorWithdrawableAmountsRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{65}
+	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ListOperatorWithdrawableAmountsRequest) GetOperatorContextFilters() *common.OperatorContextFilters {
@@ -4895,7 +4983,7 @@ type BOGetOperatorWithdrawableAmountRequest struct {
 
 func (x *BOGetOperatorWithdrawableAmountRequest) Reset() {
 	*x = BOGetOperatorWithdrawableAmountRequest{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[66]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4907,7 +4995,7 @@ func (x *BOGetOperatorWithdrawableAmountRequest) String() string {
 func (*BOGetOperatorWithdrawableAmountRequest) ProtoMessage() {}
 
 func (x *BOGetOperatorWithdrawableAmountRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[66]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4920,7 +5008,7 @@ func (x *BOGetOperatorWithdrawableAmountRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use BOGetOperatorWithdrawableAmountRequest.ProtoReflect.Descriptor instead.
 func (*BOGetOperatorWithdrawableAmountRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{66}
+	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *BOGetOperatorWithdrawableAmountRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -4951,7 +5039,7 @@ type BOListUserFreeRewardsRequest struct {
 
 func (x *BOListUserFreeRewardsRequest) Reset() {
 	*x = BOListUserFreeRewardsRequest{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[67]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4963,7 +5051,7 @@ func (x *BOListUserFreeRewardsRequest) String() string {
 func (*BOListUserFreeRewardsRequest) ProtoMessage() {}
 
 func (x *BOListUserFreeRewardsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[67]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4976,7 +5064,7 @@ func (x *BOListUserFreeRewardsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BOListUserFreeRewardsRequest.ProtoReflect.Descriptor instead.
 func (*BOListUserFreeRewardsRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{67}
+	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *BOListUserFreeRewardsRequest) GetUserId() int64 {
@@ -5043,7 +5131,7 @@ type GetWalletCreditsResponse_Credit struct {
 
 func (x *GetWalletCreditsResponse_Credit) Reset() {
 	*x = GetWalletCreditsResponse_Credit{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[68]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5055,7 +5143,7 @@ func (x *GetWalletCreditsResponse_Credit) String() string {
 func (*GetWalletCreditsResponse_Credit) ProtoMessage() {}
 
 func (x *GetWalletCreditsResponse_Credit) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[68]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5160,7 +5248,7 @@ type ListWalletBalanceTransactionsResponse_BalanceTransaction struct {
 
 func (x *ListWalletBalanceTransactionsResponse_BalanceTransaction) Reset() {
 	*x = ListWalletBalanceTransactionsResponse_BalanceTransaction{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[69]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5172,7 +5260,7 @@ func (x *ListWalletBalanceTransactionsResponse_BalanceTransaction) String() stri
 func (*ListWalletBalanceTransactionsResponse_BalanceTransaction) ProtoMessage() {}
 
 func (x *ListWalletBalanceTransactionsResponse_BalanceTransaction) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[69]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5296,7 +5384,7 @@ type GetWalletCreditTransactionsResponse_CreditTransaction struct {
 
 func (x *GetWalletCreditTransactionsResponse_CreditTransaction) Reset() {
 	*x = GetWalletCreditTransactionsResponse_CreditTransaction{}
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[70]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5308,7 +5396,7 @@ func (x *GetWalletCreditTransactionsResponse_CreditTransaction) String() string 
 func (*GetWalletCreditTransactionsResponse_CreditTransaction) ProtoMessage() {}
 
 func (x *GetWalletCreditTransactionsResponse_CreditTransaction) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[70]
+	mi := &file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5881,7 +5969,19 @@ const file_backoffice_service_v1_backoffice_wallet_proto_rawDesc = "" +
 	"\x05codes\x18\x02 \x03(\tR\x05codes\"A\n" +
 	"\x1eListUniversalCodeUsagesRequest\x12\x1f\n" +
 	"\vcampaign_id\x18\x01 \x01(\x03R\n" +
-	"campaignId\"\xe6\x01\n" +
+	"campaignId\"\xea\x01\n" +
+	"\x1eExportPromoCodeCampaignRequest\x12\x1f\n" +
+	"\vcampaign_id\x18\x01 \x01(\x03R\n" +
+	"campaignId\x12\x16\n" +
+	"\x06format\x18\x02 \x01(\tR\x06format\x12\x1b\n" +
+	"\ttime_zone\x18\x03 \x01(\tR\btimeZone\x12\x1c\n" +
+	"\auser_id\x18\x04 \x01(\x03H\x00R\x06userId\x88\x01\x01\x12\x1b\n" +
+	"\x06status\x18\x05 \x01(\tH\x01R\x06status\x88\x01\x01\x12\x17\n" +
+	"\x04code\x18\x06 \x01(\tH\x02R\x04code\x88\x01\x01B\n" +
+	"\n" +
+	"\b_user_idB\t\n" +
+	"\a_statusB\a\n" +
+	"\x05_code\"\xe6\x01\n" +
 	"&ManualAdjustCreditTurnoverFieldRequest\x12$\n" +
 	"\x0etarget_user_id\x18\x01 \x01(\x03R\ftargetUserId\x12\x1a\n" +
 	"\bcurrency\x18\x02 \x01(\tR\bcurrency\x12\x1b\n" +
@@ -5921,7 +6021,7 @@ const file_backoffice_service_v1_backoffice_wallet_proto_rawDesc = "" +
 	"\x0e_expiring_soonB\a\n" +
 	"\x05_pageB\f\n" +
 	"\n" +
-	"_page_size2\xeeQ\n" +
+	"_page_size2\xbaS\n" +
 	"\x10BackofficeWallet\x12\x8b\x01\n" +
 	"\n" +
 	"GetWallets\x12,.api.backoffice.service.v1.GetWalletsRequest\x1a).api.wallet.service.v1.GetWalletsResponse\"$\x82\xd3\xe4\x93\x02\x1e:\x01*\"\x19/v1/backoffice/wallet/get\x12\xa9\x01\n" +
@@ -5956,7 +6056,8 @@ const file_backoffice_service_v1_backoffice_wallet_proto_rawDesc = "" +
 	"\x1cListPromoCodeCampaignDetails\x12>.api.backoffice.service.v1.ListPromoCodeCampaignDetailsRequest\x1a;.api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse\"<\x82\xd3\xe4\x93\x026:\x01*\"1/v1/backoffice/wallet/promo-code/campaign/details\x12\xd7\x01\n" +
 	"\x19GenerateOneTimePromoCodes\x12;.api.backoffice.service.v1.GenerateOneTimePromoCodesRequest\x1a8.api.wallet.service.v1.GenerateOneTimePromoCodesResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/backoffice/wallet/promo-code/one-time/codes/generate\x12\xde\x01\n" +
 	"\x1bGenerateUniversalPromoCodes\x12=.api.backoffice.service.v1.GenerateUniversalPromoCodesRequest\x1a:.api.wallet.service.v1.GenerateUniversalPromoCodesResponse\"D\x82\xd3\xe4\x93\x02>:\x01*\"9/v1/backoffice/wallet/promo-code/universal/codes/generate\x12\xcf\x01\n" +
-	"\x17ListUniversalCodeUsages\x129.api.backoffice.service.v1.ListUniversalCodeUsagesRequest\x1a6.api.wallet.service.v1.ListUniversalCodeUsagesResponse\"A\x82\xd3\xe4\x93\x02;:\x01*\"6/v1/backoffice/wallet/promo-code/universal/usages/list\x12\xd1\x01\n" +
+	"\x17ListUniversalCodeUsages\x129.api.backoffice.service.v1.ListUniversalCodeUsagesRequest\x1a6.api.wallet.service.v1.ListUniversalCodeUsagesResponse\"A\x82\xd3\xe4\x93\x02;:\x01*\"6/v1/backoffice/wallet/promo-code/universal/usages/list\x12\xc9\x01\n" +
+	"\x17ExportPromoCodeCampaign\x129.api.backoffice.service.v1.ExportPromoCodeCampaignRequest\x1a6.api.wallet.service.v1.ExportPromoCodeCampaignResponse\";\x82\xd3\xe4\x93\x025:\x01*\"0/v1/backoffice/wallet/promo-code/campaign/export\x12\xd1\x01\n" +
 	"\x1dGetGamificationCurrencyConfig\x12?.api.backoffice.service.v1.GetGamificationCurrencyConfigRequest\x1a<.api.wallet.service.v1.GetGamificationCurrencyConfigResponse\"1\x82\xd3\xe4\x93\x02+:\x01*\"&/v1/backoffice/wallet/gamification/get\x12\xd4\x01\n" +
 	"\x1cUpdateOperatorCurrencyConfig\x12>.api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest\x1a;.api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse\"7\x82\xd3\xe4\x93\x021:\x01*\",/v1/backoffice/wallet/currency/config/update\x12\xad\x01\n" +
 	"\x12UpdateWalletConfig\x124.api.backoffice.service.v1.UpdateWalletConfigRequest\x1a1.api.wallet.service.v1.UpdateWalletConfigResponse\".\x82\xd3\xe4\x93\x02(:\x01*\"#/v1/backoffice/wallet/config/update\x12\xf5\x01\n" +
@@ -5990,7 +6091,7 @@ func file_backoffice_service_v1_backoffice_wallet_proto_rawDescGZIP() []byte {
 	return file_backoffice_service_v1_backoffice_wallet_proto_rawDescData
 }
 
-var file_backoffice_service_v1_backoffice_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
+var file_backoffice_service_v1_backoffice_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 74)
 var file_backoffice_service_v1_backoffice_wallet_proto_goTypes = []any{
 	(*GetWalletsRequest)(nil),                                        // 0: api.backoffice.service.v1.GetWalletsRequest
 	(*GetWalletCreditsRequest)(nil),                                  // 1: api.backoffice.service.v1.GetWalletCreditsRequest
@@ -6054,152 +6155,154 @@ var file_backoffice_service_v1_backoffice_wallet_proto_goTypes = []any{
 	(*GenerateOneTimePromoCodesRequest)(nil),                         // 59: api.backoffice.service.v1.GenerateOneTimePromoCodesRequest
 	(*GenerateUniversalPromoCodesRequest)(nil),                       // 60: api.backoffice.service.v1.GenerateUniversalPromoCodesRequest
 	(*ListUniversalCodeUsagesRequest)(nil),                           // 61: api.backoffice.service.v1.ListUniversalCodeUsagesRequest
-	(*ManualAdjustCreditTurnoverFieldRequest)(nil),                   // 62: api.backoffice.service.v1.ManualAdjustCreditTurnoverFieldRequest
-	(*SetAppDownloadRewardConfigRequest)(nil),                        // 63: api.backoffice.service.v1.SetAppDownloadRewardConfigRequest
-	(*GetAppDownloadRewardConfigRequest)(nil),                        // 64: api.backoffice.service.v1.GetAppDownloadRewardConfigRequest
-	(*ListOperatorWithdrawableAmountsRequest)(nil),                   // 65: api.backoffice.service.v1.ListOperatorWithdrawableAmountsRequest
-	(*BOGetOperatorWithdrawableAmountRequest)(nil),                   // 66: api.backoffice.service.v1.BOGetOperatorWithdrawableAmountRequest
-	(*BOListUserFreeRewardsRequest)(nil),                             // 67: api.backoffice.service.v1.BOListUserFreeRewardsRequest
-	(*GetWalletCreditsResponse_Credit)(nil),                          // 68: api.backoffice.service.v1.GetWalletCreditsResponse.Credit
-	(*ListWalletBalanceTransactionsResponse_BalanceTransaction)(nil), // 69: api.backoffice.service.v1.ListWalletBalanceTransactionsResponse.BalanceTransaction
-	(*GetWalletCreditTransactionsResponse_CreditTransaction)(nil),    // 70: api.backoffice.service.v1.GetWalletCreditTransactionsResponse.CreditTransaction
-	nil,                                                // 71: api.backoffice.service.v1.GetExchangeRatesResponse.ExchangeRatesEntry
-	nil,                                                // 72: api.backoffice.service.v1.GetExchangeRatesResponse.SwapFeesEntry
-	(*timestamppb.Timestamp)(nil),                      // 73: google.protobuf.Timestamp
-	(*common.OperatorContext)(nil),                     // 74: api.common.OperatorContext
-	(*common.OperatorContextFilters)(nil),              // 75: api.common.OperatorContextFilters
-	(*v1.RewardSequence)(nil),                          // 76: api.wallet.service.v1.RewardSequence
-	(*v1.OperatorCurrencyConfig)(nil),                  // 77: api.wallet.service.v1.OperatorCurrencyConfig
-	(*v1.WalletConfig)(nil),                            // 78: api.wallet.service.v1.WalletConfig
-	(*v1.FICAThresholdConfig)(nil),                     // 79: api.wallet.service.v1.FICAThresholdConfig
-	(*v1.PromoCodeConditions)(nil),                     // 80: api.wallet.service.v1.PromoCodeConditions
-	(*v1.PromoCodeRewardConfigs)(nil),                  // 81: api.wallet.service.v1.PromoCodeRewardConfigs
-	(*v1.AppDownloadRewardConfigItem)(nil),             // 82: api.wallet.service.v1.AppDownloadRewardConfigItem
-	(*v1.GetWalletsResponse)(nil),                      // 83: api.wallet.service.v1.GetWalletsResponse
-	(*v1.ListCurrenciesResponse)(nil),                  // 84: api.wallet.service.v1.ListCurrenciesResponse
-	(*v1.UpdateOperatorCurrencyResponse)(nil),          // 85: api.wallet.service.v1.UpdateOperatorCurrencyResponse
-	(*v1.ListBottomOperatorBalancesResponse)(nil),      // 86: api.wallet.service.v1.ListBottomOperatorBalancesResponse
-	(*v1.ListCompanyOperatorBalancesResponse)(nil),     // 87: api.wallet.service.v1.ListCompanyOperatorBalancesResponse
-	(*v1.GetOperatorBalanceResponse)(nil),              // 88: api.wallet.service.v1.GetOperatorBalanceResponse
-	(*v1.SetDepositRewardSequencesResponse)(nil),       // 89: api.wallet.service.v1.SetDepositRewardSequencesResponse
-	(*v1.DeleteDepositRewardSequencesResponse)(nil),    // 90: api.wallet.service.v1.DeleteDepositRewardSequencesResponse
-	(*v1.GetDepositRewardConfigResponse)(nil),          // 91: api.wallet.service.v1.GetDepositRewardConfigResponse
-	(*v1.SetAppDownloadRewardConfigResponse)(nil),      // 92: api.wallet.service.v1.SetAppDownloadRewardConfigResponse
-	(*v1.GetAppDownloadRewardConfigResponse)(nil),      // 93: api.wallet.service.v1.GetAppDownloadRewardConfigResponse
-	(*v1.CreatePromoCodeCampaignResponse)(nil),         // 94: api.wallet.service.v1.CreatePromoCodeCampaignResponse
-	(*v1.UpdatePromoCodeCampaignResponse)(nil),         // 95: api.wallet.service.v1.UpdatePromoCodeCampaignResponse
-	(*v1.UpdatePromoCodeCampaignStatusResponse)(nil),   // 96: api.wallet.service.v1.UpdatePromoCodeCampaignStatusResponse
-	(*v1.ListPromoCodeCampaignsResponse)(nil),          // 97: api.wallet.service.v1.ListPromoCodeCampaignsResponse
-	(*v1.ListPromoCodeCampaignDetailsResponse)(nil),    // 98: api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse
-	(*v1.GenerateOneTimePromoCodesResponse)(nil),       // 99: api.wallet.service.v1.GenerateOneTimePromoCodesResponse
-	(*v1.GenerateUniversalPromoCodesResponse)(nil),     // 100: api.wallet.service.v1.GenerateUniversalPromoCodesResponse
-	(*v1.ListUniversalCodeUsagesResponse)(nil),         // 101: api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	(*v1.GetGamificationCurrencyConfigResponse)(nil),   // 102: api.wallet.service.v1.GetGamificationCurrencyConfigResponse
-	(*v1.UpdateOperatorCurrencyConfigResponse)(nil),    // 103: api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse
-	(*v1.UpdateWalletConfigResponse)(nil),              // 104: api.wallet.service.v1.UpdateWalletConfigResponse
-	(*v1.DeleteResponsibleGamblingConfigResponse)(nil), // 105: api.wallet.service.v1.DeleteResponsibleGamblingConfigResponse
-	(*v1.ListResponsibleGamblingConfigsResponse)(nil),  // 106: api.wallet.service.v1.ListResponsibleGamblingConfigsResponse
-	(*v1.ListCustomerRecordsResponse)(nil),             // 107: api.wallet.service.v1.ListCustomerRecordsResponse
-	(*v1.ExportCustomerRecordsResponse)(nil),           // 108: api.wallet.service.v1.ExportCustomerRecordsResponse
-	(*v1.SetFICAThresholdConfigResponse)(nil),          // 109: api.wallet.service.v1.SetFICAThresholdConfigResponse
-	(*v1.GetFICAThresholdConfigResponse)(nil),          // 110: api.wallet.service.v1.GetFICAThresholdConfigResponse
-	(*v1.ListFICAThresholdTransactionsResponse)(nil),   // 111: api.wallet.service.v1.ListFICAThresholdTransactionsResponse
-	(*v1.ExportFICAThresholdTransactionsResponse)(nil), // 112: api.wallet.service.v1.ExportFICAThresholdTransactionsResponse
-	(*v1.CreditResponse)(nil),                          // 113: api.wallet.service.v1.CreditResponse
-	(*v1.DebitResponse)(nil),                           // 114: api.wallet.service.v1.DebitResponse
-	(*v1.ListManualJournalEntriesResponse)(nil),        // 115: api.wallet.service.v1.ListManualJournalEntriesResponse
-	(*v1.ExportManualJournalEntriesResponse)(nil),      // 116: api.wallet.service.v1.ExportManualJournalEntriesResponse
-	(*v1.ManualAdjustCreditTurnoverFieldResponse)(nil), // 117: api.wallet.service.v1.ManualAdjustCreditTurnoverFieldResponse
-	(*v1.ListOperatorWithdrawableAmountsResponse)(nil), // 118: api.wallet.service.v1.ListOperatorWithdrawableAmountsResponse
-	(*v1.GetOperatorWithdrawableAmountResponse)(nil),   // 119: api.wallet.service.v1.GetOperatorWithdrawableAmountResponse
-	(*v1.ListUserFreeRewardsBOResponse)(nil),           // 120: api.wallet.service.v1.ListUserFreeRewardsBOResponse
+	(*ExportPromoCodeCampaignRequest)(nil),                           // 62: api.backoffice.service.v1.ExportPromoCodeCampaignRequest
+	(*ManualAdjustCreditTurnoverFieldRequest)(nil),                   // 63: api.backoffice.service.v1.ManualAdjustCreditTurnoverFieldRequest
+	(*SetAppDownloadRewardConfigRequest)(nil),                        // 64: api.backoffice.service.v1.SetAppDownloadRewardConfigRequest
+	(*GetAppDownloadRewardConfigRequest)(nil),                        // 65: api.backoffice.service.v1.GetAppDownloadRewardConfigRequest
+	(*ListOperatorWithdrawableAmountsRequest)(nil),                   // 66: api.backoffice.service.v1.ListOperatorWithdrawableAmountsRequest
+	(*BOGetOperatorWithdrawableAmountRequest)(nil),                   // 67: api.backoffice.service.v1.BOGetOperatorWithdrawableAmountRequest
+	(*BOListUserFreeRewardsRequest)(nil),                             // 68: api.backoffice.service.v1.BOListUserFreeRewardsRequest
+	(*GetWalletCreditsResponse_Credit)(nil),                          // 69: api.backoffice.service.v1.GetWalletCreditsResponse.Credit
+	(*ListWalletBalanceTransactionsResponse_BalanceTransaction)(nil), // 70: api.backoffice.service.v1.ListWalletBalanceTransactionsResponse.BalanceTransaction
+	(*GetWalletCreditTransactionsResponse_CreditTransaction)(nil),    // 71: api.backoffice.service.v1.GetWalletCreditTransactionsResponse.CreditTransaction
+	nil,                                                // 72: api.backoffice.service.v1.GetExchangeRatesResponse.ExchangeRatesEntry
+	nil,                                                // 73: api.backoffice.service.v1.GetExchangeRatesResponse.SwapFeesEntry
+	(*timestamppb.Timestamp)(nil),                      // 74: google.protobuf.Timestamp
+	(*common.OperatorContext)(nil),                     // 75: api.common.OperatorContext
+	(*common.OperatorContextFilters)(nil),              // 76: api.common.OperatorContextFilters
+	(*v1.RewardSequence)(nil),                          // 77: api.wallet.service.v1.RewardSequence
+	(*v1.OperatorCurrencyConfig)(nil),                  // 78: api.wallet.service.v1.OperatorCurrencyConfig
+	(*v1.WalletConfig)(nil),                            // 79: api.wallet.service.v1.WalletConfig
+	(*v1.FICAThresholdConfig)(nil),                     // 80: api.wallet.service.v1.FICAThresholdConfig
+	(*v1.PromoCodeConditions)(nil),                     // 81: api.wallet.service.v1.PromoCodeConditions
+	(*v1.PromoCodeRewardConfigs)(nil),                  // 82: api.wallet.service.v1.PromoCodeRewardConfigs
+	(*v1.AppDownloadRewardConfigItem)(nil),             // 83: api.wallet.service.v1.AppDownloadRewardConfigItem
+	(*v1.GetWalletsResponse)(nil),                      // 84: api.wallet.service.v1.GetWalletsResponse
+	(*v1.ListCurrenciesResponse)(nil),                  // 85: api.wallet.service.v1.ListCurrenciesResponse
+	(*v1.UpdateOperatorCurrencyResponse)(nil),          // 86: api.wallet.service.v1.UpdateOperatorCurrencyResponse
+	(*v1.ListBottomOperatorBalancesResponse)(nil),      // 87: api.wallet.service.v1.ListBottomOperatorBalancesResponse
+	(*v1.ListCompanyOperatorBalancesResponse)(nil),     // 88: api.wallet.service.v1.ListCompanyOperatorBalancesResponse
+	(*v1.GetOperatorBalanceResponse)(nil),              // 89: api.wallet.service.v1.GetOperatorBalanceResponse
+	(*v1.SetDepositRewardSequencesResponse)(nil),       // 90: api.wallet.service.v1.SetDepositRewardSequencesResponse
+	(*v1.DeleteDepositRewardSequencesResponse)(nil),    // 91: api.wallet.service.v1.DeleteDepositRewardSequencesResponse
+	(*v1.GetDepositRewardConfigResponse)(nil),          // 92: api.wallet.service.v1.GetDepositRewardConfigResponse
+	(*v1.SetAppDownloadRewardConfigResponse)(nil),      // 93: api.wallet.service.v1.SetAppDownloadRewardConfigResponse
+	(*v1.GetAppDownloadRewardConfigResponse)(nil),      // 94: api.wallet.service.v1.GetAppDownloadRewardConfigResponse
+	(*v1.CreatePromoCodeCampaignResponse)(nil),         // 95: api.wallet.service.v1.CreatePromoCodeCampaignResponse
+	(*v1.UpdatePromoCodeCampaignResponse)(nil),         // 96: api.wallet.service.v1.UpdatePromoCodeCampaignResponse
+	(*v1.UpdatePromoCodeCampaignStatusResponse)(nil),   // 97: api.wallet.service.v1.UpdatePromoCodeCampaignStatusResponse
+	(*v1.ListPromoCodeCampaignsResponse)(nil),          // 98: api.wallet.service.v1.ListPromoCodeCampaignsResponse
+	(*v1.ListPromoCodeCampaignDetailsResponse)(nil),    // 99: api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse
+	(*v1.GenerateOneTimePromoCodesResponse)(nil),       // 100: api.wallet.service.v1.GenerateOneTimePromoCodesResponse
+	(*v1.GenerateUniversalPromoCodesResponse)(nil),     // 101: api.wallet.service.v1.GenerateUniversalPromoCodesResponse
+	(*v1.ListUniversalCodeUsagesResponse)(nil),         // 102: api.wallet.service.v1.ListUniversalCodeUsagesResponse
+	(*v1.ExportPromoCodeCampaignResponse)(nil),         // 103: api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	(*v1.GetGamificationCurrencyConfigResponse)(nil),   // 104: api.wallet.service.v1.GetGamificationCurrencyConfigResponse
+	(*v1.UpdateOperatorCurrencyConfigResponse)(nil),    // 105: api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse
+	(*v1.UpdateWalletConfigResponse)(nil),              // 106: api.wallet.service.v1.UpdateWalletConfigResponse
+	(*v1.DeleteResponsibleGamblingConfigResponse)(nil), // 107: api.wallet.service.v1.DeleteResponsibleGamblingConfigResponse
+	(*v1.ListResponsibleGamblingConfigsResponse)(nil),  // 108: api.wallet.service.v1.ListResponsibleGamblingConfigsResponse
+	(*v1.ListCustomerRecordsResponse)(nil),             // 109: api.wallet.service.v1.ListCustomerRecordsResponse
+	(*v1.ExportCustomerRecordsResponse)(nil),           // 110: api.wallet.service.v1.ExportCustomerRecordsResponse
+	(*v1.SetFICAThresholdConfigResponse)(nil),          // 111: api.wallet.service.v1.SetFICAThresholdConfigResponse
+	(*v1.GetFICAThresholdConfigResponse)(nil),          // 112: api.wallet.service.v1.GetFICAThresholdConfigResponse
+	(*v1.ListFICAThresholdTransactionsResponse)(nil),   // 113: api.wallet.service.v1.ListFICAThresholdTransactionsResponse
+	(*v1.ExportFICAThresholdTransactionsResponse)(nil), // 114: api.wallet.service.v1.ExportFICAThresholdTransactionsResponse
+	(*v1.CreditResponse)(nil),                          // 115: api.wallet.service.v1.CreditResponse
+	(*v1.DebitResponse)(nil),                           // 116: api.wallet.service.v1.DebitResponse
+	(*v1.ListManualJournalEntriesResponse)(nil),        // 117: api.wallet.service.v1.ListManualJournalEntriesResponse
+	(*v1.ExportManualJournalEntriesResponse)(nil),      // 118: api.wallet.service.v1.ExportManualJournalEntriesResponse
+	(*v1.ManualAdjustCreditTurnoverFieldResponse)(nil), // 119: api.wallet.service.v1.ManualAdjustCreditTurnoverFieldResponse
+	(*v1.ListOperatorWithdrawableAmountsResponse)(nil), // 120: api.wallet.service.v1.ListOperatorWithdrawableAmountsResponse
+	(*v1.GetOperatorWithdrawableAmountResponse)(nil),   // 121: api.wallet.service.v1.GetOperatorWithdrawableAmountResponse
+	(*v1.ListUserFreeRewardsBOResponse)(nil),           // 122: api.wallet.service.v1.ListUserFreeRewardsBOResponse
 }
 var file_backoffice_service_v1_backoffice_wallet_proto_depIdxs = []int32{
-	73,  // 0: api.backoffice.service.v1.GetWalletCreditsRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 1: api.backoffice.service.v1.GetWalletCreditsRequest.end_time:type_name -> google.protobuf.Timestamp
-	68,  // 2: api.backoffice.service.v1.GetWalletCreditsResponse.credits:type_name -> api.backoffice.service.v1.GetWalletCreditsResponse.Credit
-	73,  // 3: api.backoffice.service.v1.ListWalletBalanceTransactionsRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 4: api.backoffice.service.v1.ListWalletBalanceTransactionsRequest.end_time:type_name -> google.protobuf.Timestamp
-	69,  // 5: api.backoffice.service.v1.ListWalletBalanceTransactionsResponse.balance_transactions:type_name -> api.backoffice.service.v1.ListWalletBalanceTransactionsResponse.BalanceTransaction
-	70,  // 6: api.backoffice.service.v1.GetWalletCreditTransactionsResponse.credit_transactions:type_name -> api.backoffice.service.v1.GetWalletCreditTransactionsResponse.CreditTransaction
-	74,  // 7: api.backoffice.service.v1.ListWalletCurrenciesRequest.target_operator_context:type_name -> api.common.OperatorContext
-	74,  // 8: api.backoffice.service.v1.UpdateWalletCurrencyRequest.target_operator_context:type_name -> api.common.OperatorContext
-	75,  // 9: api.backoffice.service.v1.ListOperatorBalancesRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
-	75,  // 10: api.backoffice.service.v1.ListCompanyBalancesRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
-	71,  // 11: api.backoffice.service.v1.GetExchangeRatesResponse.exchange_rates:type_name -> api.backoffice.service.v1.GetExchangeRatesResponse.ExchangeRatesEntry
-	72,  // 12: api.backoffice.service.v1.GetExchangeRatesResponse.swap_fees:type_name -> api.backoffice.service.v1.GetExchangeRatesResponse.SwapFeesEntry
-	74,  // 13: api.backoffice.service.v1.OperatorTransferRequest.operator_context:type_name -> api.common.OperatorContext
-	74,  // 14: api.backoffice.service.v1.OperatorSwapRequest.source_operator_context:type_name -> api.common.OperatorContext
-	74,  // 15: api.backoffice.service.v1.OperatorSwapRequest.target_operator_context:type_name -> api.common.OperatorContext
-	74,  // 16: api.backoffice.service.v1.OperatorBalanceFreezeRequest.operator_context:type_name -> api.common.OperatorContext
-	74,  // 17: api.backoffice.service.v1.OperatorBalanceRollbackRequest.operator_context:type_name -> api.common.OperatorContext
-	74,  // 18: api.backoffice.service.v1.OperatorBalanceSettleRequest.operator_context:type_name -> api.common.OperatorContext
-	74,  // 19: api.backoffice.service.v1.OperatorBalanceAdjustRequest.operator_context:type_name -> api.common.OperatorContext
-	75,  // 20: api.backoffice.service.v1.ListOperatorBalanceTransactionsRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
-	73,  // 21: api.backoffice.service.v1.ListOperatorBalanceTransactionsRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 22: api.backoffice.service.v1.ListOperatorBalanceTransactionsRequest.end_time:type_name -> google.protobuf.Timestamp
-	74,  // 23: api.backoffice.service.v1.OperatorBalanceTransaction.operator_context:type_name -> api.common.OperatorContext
-	73,  // 24: api.backoffice.service.v1.OperatorBalanceTransaction.created_at:type_name -> google.protobuf.Timestamp
-	73,  // 25: api.backoffice.service.v1.OperatorBalanceTransaction.updated_at:type_name -> google.protobuf.Timestamp
+	74,  // 0: api.backoffice.service.v1.GetWalletCreditsRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 1: api.backoffice.service.v1.GetWalletCreditsRequest.end_time:type_name -> google.protobuf.Timestamp
+	69,  // 2: api.backoffice.service.v1.GetWalletCreditsResponse.credits:type_name -> api.backoffice.service.v1.GetWalletCreditsResponse.Credit
+	74,  // 3: api.backoffice.service.v1.ListWalletBalanceTransactionsRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 4: api.backoffice.service.v1.ListWalletBalanceTransactionsRequest.end_time:type_name -> google.protobuf.Timestamp
+	70,  // 5: api.backoffice.service.v1.ListWalletBalanceTransactionsResponse.balance_transactions:type_name -> api.backoffice.service.v1.ListWalletBalanceTransactionsResponse.BalanceTransaction
+	71,  // 6: api.backoffice.service.v1.GetWalletCreditTransactionsResponse.credit_transactions:type_name -> api.backoffice.service.v1.GetWalletCreditTransactionsResponse.CreditTransaction
+	75,  // 7: api.backoffice.service.v1.ListWalletCurrenciesRequest.target_operator_context:type_name -> api.common.OperatorContext
+	75,  // 8: api.backoffice.service.v1.UpdateWalletCurrencyRequest.target_operator_context:type_name -> api.common.OperatorContext
+	76,  // 9: api.backoffice.service.v1.ListOperatorBalancesRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
+	76,  // 10: api.backoffice.service.v1.ListCompanyBalancesRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
+	72,  // 11: api.backoffice.service.v1.GetExchangeRatesResponse.exchange_rates:type_name -> api.backoffice.service.v1.GetExchangeRatesResponse.ExchangeRatesEntry
+	73,  // 12: api.backoffice.service.v1.GetExchangeRatesResponse.swap_fees:type_name -> api.backoffice.service.v1.GetExchangeRatesResponse.SwapFeesEntry
+	75,  // 13: api.backoffice.service.v1.OperatorTransferRequest.operator_context:type_name -> api.common.OperatorContext
+	75,  // 14: api.backoffice.service.v1.OperatorSwapRequest.source_operator_context:type_name -> api.common.OperatorContext
+	75,  // 15: api.backoffice.service.v1.OperatorSwapRequest.target_operator_context:type_name -> api.common.OperatorContext
+	75,  // 16: api.backoffice.service.v1.OperatorBalanceFreezeRequest.operator_context:type_name -> api.common.OperatorContext
+	75,  // 17: api.backoffice.service.v1.OperatorBalanceRollbackRequest.operator_context:type_name -> api.common.OperatorContext
+	75,  // 18: api.backoffice.service.v1.OperatorBalanceSettleRequest.operator_context:type_name -> api.common.OperatorContext
+	75,  // 19: api.backoffice.service.v1.OperatorBalanceAdjustRequest.operator_context:type_name -> api.common.OperatorContext
+	76,  // 20: api.backoffice.service.v1.ListOperatorBalanceTransactionsRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
+	74,  // 21: api.backoffice.service.v1.ListOperatorBalanceTransactionsRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 22: api.backoffice.service.v1.ListOperatorBalanceTransactionsRequest.end_time:type_name -> google.protobuf.Timestamp
+	75,  // 23: api.backoffice.service.v1.OperatorBalanceTransaction.operator_context:type_name -> api.common.OperatorContext
+	74,  // 24: api.backoffice.service.v1.OperatorBalanceTransaction.created_at:type_name -> google.protobuf.Timestamp
+	74,  // 25: api.backoffice.service.v1.OperatorBalanceTransaction.updated_at:type_name -> google.protobuf.Timestamp
 	31,  // 26: api.backoffice.service.v1.ListOperatorBalanceTransactionsResponse.transactions:type_name -> api.backoffice.service.v1.OperatorBalanceTransaction
-	74,  // 27: api.backoffice.service.v1.UpdateOperatorBalanceRequest.target_operator_context:type_name -> api.common.OperatorContext
-	74,  // 28: api.backoffice.service.v1.GetOperatorBalanceRequest.operator_context:type_name -> api.common.OperatorContext
-	74,  // 29: api.backoffice.service.v1.SetDepositRewardSequencesRequest.target_operator_context:type_name -> api.common.OperatorContext
-	76,  // 30: api.backoffice.service.v1.SetDepositRewardSequencesRequest.welcome_reward_sequences:type_name -> api.wallet.service.v1.RewardSequence
-	76,  // 31: api.backoffice.service.v1.SetDepositRewardSequencesRequest.daily_reward_sequences:type_name -> api.wallet.service.v1.RewardSequence
-	74,  // 32: api.backoffice.service.v1.DeleteDepositRewardSequencesRequest.target_operator_context:type_name -> api.common.OperatorContext
-	76,  // 33: api.backoffice.service.v1.DeleteDepositRewardSequencesRequest.welcome_reward_sequences:type_name -> api.wallet.service.v1.RewardSequence
-	76,  // 34: api.backoffice.service.v1.DeleteDepositRewardSequencesRequest.daily_reward_sequences:type_name -> api.wallet.service.v1.RewardSequence
-	74,  // 35: api.backoffice.service.v1.GetDepositRewardConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	74,  // 36: api.backoffice.service.v1.GetGamificationCurrencyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	74,  // 37: api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	77,  // 38: api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest.operator_currency_config:type_name -> api.wallet.service.v1.OperatorCurrencyConfig
-	74,  // 39: api.backoffice.service.v1.UpdateWalletConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	78,  // 40: api.backoffice.service.v1.UpdateWalletConfigRequest.wallet_config:type_name -> api.wallet.service.v1.WalletConfig
-	73,  // 41: api.backoffice.service.v1.ListCustomerRecordsRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 42: api.backoffice.service.v1.ListCustomerRecordsRequest.end_time:type_name -> google.protobuf.Timestamp
-	75,  // 43: api.backoffice.service.v1.ListCustomerRecordsRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
-	73,  // 44: api.backoffice.service.v1.ExportCustomerRecordsRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 45: api.backoffice.service.v1.ExportCustomerRecordsRequest.end_time:type_name -> google.protobuf.Timestamp
-	75,  // 46: api.backoffice.service.v1.ExportCustomerRecordsRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
-	79,  // 47: api.backoffice.service.v1.SetFICAThresholdConfigRequest.fica_threshold_config:type_name -> api.wallet.service.v1.FICAThresholdConfig
-	74,  // 48: api.backoffice.service.v1.SetFICAThresholdConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	74,  // 49: api.backoffice.service.v1.GetFICAThresholdConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	73,  // 50: api.backoffice.service.v1.ListFICAThresholdTransactionsRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 51: api.backoffice.service.v1.ListFICAThresholdTransactionsRequest.end_time:type_name -> google.protobuf.Timestamp
-	74,  // 52: api.backoffice.service.v1.ListFICAThresholdTransactionsRequest.target_operator_context:type_name -> api.common.OperatorContext
-	73,  // 53: api.backoffice.service.v1.ExportFICAThresholdTransactionsRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 54: api.backoffice.service.v1.ExportFICAThresholdTransactionsRequest.end_time:type_name -> google.protobuf.Timestamp
-	74,  // 55: api.backoffice.service.v1.ExportFICAThresholdTransactionsRequest.target_operator_context:type_name -> api.common.OperatorContext
-	73,  // 56: api.backoffice.service.v1.ListManualJournalEntriesRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 57: api.backoffice.service.v1.ListManualJournalEntriesRequest.end_time:type_name -> google.protobuf.Timestamp
-	75,  // 58: api.backoffice.service.v1.ListManualJournalEntriesRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
-	73,  // 59: api.backoffice.service.v1.ExportManualJournalEntriesRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 60: api.backoffice.service.v1.ExportManualJournalEntriesRequest.end_time:type_name -> google.protobuf.Timestamp
-	75,  // 61: api.backoffice.service.v1.ExportManualJournalEntriesRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
-	74,  // 62: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.target_operator_context:type_name -> api.common.OperatorContext
-	73,  // 63: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 64: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.end_time:type_name -> google.protobuf.Timestamp
-	80,  // 65: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
-	81,  // 66: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
-	74,  // 67: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.target_operator_context:type_name -> api.common.OperatorContext
-	73,  // 68: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 69: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.end_time:type_name -> google.protobuf.Timestamp
-	80,  // 70: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
-	81,  // 71: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
-	74,  // 72: api.backoffice.service.v1.UpdatePromoCodeCampaignStatusRequest.target_operator_context:type_name -> api.common.OperatorContext
-	74,  // 73: api.backoffice.service.v1.ListPromoCodeCampaignsRequest.target_operator_context:type_name -> api.common.OperatorContext
-	73,  // 74: api.backoffice.service.v1.ListPromoCodeCampaignsRequest.start_time:type_name -> google.protobuf.Timestamp
-	73,  // 75: api.backoffice.service.v1.ListPromoCodeCampaignsRequest.end_time:type_name -> google.protobuf.Timestamp
-	74,  // 76: api.backoffice.service.v1.SetAppDownloadRewardConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	82,  // 77: api.backoffice.service.v1.SetAppDownloadRewardConfigRequest.configs:type_name -> api.wallet.service.v1.AppDownloadRewardConfigItem
-	74,  // 78: api.backoffice.service.v1.GetAppDownloadRewardConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	75,  // 79: api.backoffice.service.v1.ListOperatorWithdrawableAmountsRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
-	74,  // 80: api.backoffice.service.v1.ListOperatorWithdrawableAmountsRequest.target_operator_context:type_name -> api.common.OperatorContext
-	74,  // 81: api.backoffice.service.v1.BOGetOperatorWithdrawableAmountRequest.target_operator_context:type_name -> api.common.OperatorContext
-	73,  // 82: api.backoffice.service.v1.GetWalletCreditsResponse.Credit.created_at:type_name -> google.protobuf.Timestamp
-	73,  // 83: api.backoffice.service.v1.ListWalletBalanceTransactionsResponse.BalanceTransaction.created_at:type_name -> google.protobuf.Timestamp
-	73,  // 84: api.backoffice.service.v1.GetWalletCreditTransactionsResponse.CreditTransaction.created_at:type_name -> google.protobuf.Timestamp
+	75,  // 27: api.backoffice.service.v1.UpdateOperatorBalanceRequest.target_operator_context:type_name -> api.common.OperatorContext
+	75,  // 28: api.backoffice.service.v1.GetOperatorBalanceRequest.operator_context:type_name -> api.common.OperatorContext
+	75,  // 29: api.backoffice.service.v1.SetDepositRewardSequencesRequest.target_operator_context:type_name -> api.common.OperatorContext
+	77,  // 30: api.backoffice.service.v1.SetDepositRewardSequencesRequest.welcome_reward_sequences:type_name -> api.wallet.service.v1.RewardSequence
+	77,  // 31: api.backoffice.service.v1.SetDepositRewardSequencesRequest.daily_reward_sequences:type_name -> api.wallet.service.v1.RewardSequence
+	75,  // 32: api.backoffice.service.v1.DeleteDepositRewardSequencesRequest.target_operator_context:type_name -> api.common.OperatorContext
+	77,  // 33: api.backoffice.service.v1.DeleteDepositRewardSequencesRequest.welcome_reward_sequences:type_name -> api.wallet.service.v1.RewardSequence
+	77,  // 34: api.backoffice.service.v1.DeleteDepositRewardSequencesRequest.daily_reward_sequences:type_name -> api.wallet.service.v1.RewardSequence
+	75,  // 35: api.backoffice.service.v1.GetDepositRewardConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	75,  // 36: api.backoffice.service.v1.GetGamificationCurrencyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	75,  // 37: api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	78,  // 38: api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest.operator_currency_config:type_name -> api.wallet.service.v1.OperatorCurrencyConfig
+	75,  // 39: api.backoffice.service.v1.UpdateWalletConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	79,  // 40: api.backoffice.service.v1.UpdateWalletConfigRequest.wallet_config:type_name -> api.wallet.service.v1.WalletConfig
+	74,  // 41: api.backoffice.service.v1.ListCustomerRecordsRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 42: api.backoffice.service.v1.ListCustomerRecordsRequest.end_time:type_name -> google.protobuf.Timestamp
+	76,  // 43: api.backoffice.service.v1.ListCustomerRecordsRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
+	74,  // 44: api.backoffice.service.v1.ExportCustomerRecordsRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 45: api.backoffice.service.v1.ExportCustomerRecordsRequest.end_time:type_name -> google.protobuf.Timestamp
+	76,  // 46: api.backoffice.service.v1.ExportCustomerRecordsRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
+	80,  // 47: api.backoffice.service.v1.SetFICAThresholdConfigRequest.fica_threshold_config:type_name -> api.wallet.service.v1.FICAThresholdConfig
+	75,  // 48: api.backoffice.service.v1.SetFICAThresholdConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	75,  // 49: api.backoffice.service.v1.GetFICAThresholdConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	74,  // 50: api.backoffice.service.v1.ListFICAThresholdTransactionsRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 51: api.backoffice.service.v1.ListFICAThresholdTransactionsRequest.end_time:type_name -> google.protobuf.Timestamp
+	75,  // 52: api.backoffice.service.v1.ListFICAThresholdTransactionsRequest.target_operator_context:type_name -> api.common.OperatorContext
+	74,  // 53: api.backoffice.service.v1.ExportFICAThresholdTransactionsRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 54: api.backoffice.service.v1.ExportFICAThresholdTransactionsRequest.end_time:type_name -> google.protobuf.Timestamp
+	75,  // 55: api.backoffice.service.v1.ExportFICAThresholdTransactionsRequest.target_operator_context:type_name -> api.common.OperatorContext
+	74,  // 56: api.backoffice.service.v1.ListManualJournalEntriesRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 57: api.backoffice.service.v1.ListManualJournalEntriesRequest.end_time:type_name -> google.protobuf.Timestamp
+	76,  // 58: api.backoffice.service.v1.ListManualJournalEntriesRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
+	74,  // 59: api.backoffice.service.v1.ExportManualJournalEntriesRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 60: api.backoffice.service.v1.ExportManualJournalEntriesRequest.end_time:type_name -> google.protobuf.Timestamp
+	76,  // 61: api.backoffice.service.v1.ExportManualJournalEntriesRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
+	75,  // 62: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.target_operator_context:type_name -> api.common.OperatorContext
+	74,  // 63: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 64: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.end_time:type_name -> google.protobuf.Timestamp
+	81,  // 65: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
+	82,  // 66: api.backoffice.service.v1.CreatePromoCodeCampaignRequest.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
+	75,  // 67: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.target_operator_context:type_name -> api.common.OperatorContext
+	74,  // 68: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 69: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.end_time:type_name -> google.protobuf.Timestamp
+	81,  // 70: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
+	82,  // 71: api.backoffice.service.v1.UpdatePromoCodeCampaignRequest.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
+	75,  // 72: api.backoffice.service.v1.UpdatePromoCodeCampaignStatusRequest.target_operator_context:type_name -> api.common.OperatorContext
+	75,  // 73: api.backoffice.service.v1.ListPromoCodeCampaignsRequest.target_operator_context:type_name -> api.common.OperatorContext
+	74,  // 74: api.backoffice.service.v1.ListPromoCodeCampaignsRequest.start_time:type_name -> google.protobuf.Timestamp
+	74,  // 75: api.backoffice.service.v1.ListPromoCodeCampaignsRequest.end_time:type_name -> google.protobuf.Timestamp
+	75,  // 76: api.backoffice.service.v1.SetAppDownloadRewardConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	83,  // 77: api.backoffice.service.v1.SetAppDownloadRewardConfigRequest.configs:type_name -> api.wallet.service.v1.AppDownloadRewardConfigItem
+	75,  // 78: api.backoffice.service.v1.GetAppDownloadRewardConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	76,  // 79: api.backoffice.service.v1.ListOperatorWithdrawableAmountsRequest.operator_context_filters:type_name -> api.common.OperatorContextFilters
+	75,  // 80: api.backoffice.service.v1.ListOperatorWithdrawableAmountsRequest.target_operator_context:type_name -> api.common.OperatorContext
+	75,  // 81: api.backoffice.service.v1.BOGetOperatorWithdrawableAmountRequest.target_operator_context:type_name -> api.common.OperatorContext
+	74,  // 82: api.backoffice.service.v1.GetWalletCreditsResponse.Credit.created_at:type_name -> google.protobuf.Timestamp
+	74,  // 83: api.backoffice.service.v1.ListWalletBalanceTransactionsResponse.BalanceTransaction.created_at:type_name -> google.protobuf.Timestamp
+	74,  // 84: api.backoffice.service.v1.GetWalletCreditTransactionsResponse.CreditTransaction.created_at:type_name -> google.protobuf.Timestamp
 	0,   // 85: api.backoffice.service.v1.BackofficeWallet.GetWallets:input_type -> api.backoffice.service.v1.GetWalletsRequest
 	1,   // 86: api.backoffice.service.v1.BackofficeWallet.GetWalletCredits:input_type -> api.backoffice.service.v1.GetWalletCreditsRequest
 	3,   // 87: api.backoffice.service.v1.BackofficeWallet.ListWalletBalanceTransactions:input_type -> api.backoffice.service.v1.ListWalletBalanceTransactionsRequest
@@ -6223,8 +6326,8 @@ var file_backoffice_service_v1_backoffice_wallet_proto_depIdxs = []int32{
 	36,  // 105: api.backoffice.service.v1.BackofficeWallet.SetDepositRewardSequences:input_type -> api.backoffice.service.v1.SetDepositRewardSequencesRequest
 	37,  // 106: api.backoffice.service.v1.BackofficeWallet.DeleteDepositRewardSequences:input_type -> api.backoffice.service.v1.DeleteDepositRewardSequencesRequest
 	38,  // 107: api.backoffice.service.v1.BackofficeWallet.GetDepositRewardConfig:input_type -> api.backoffice.service.v1.GetDepositRewardConfigRequest
-	63,  // 108: api.backoffice.service.v1.BackofficeWallet.SetAppDownloadRewardConfig:input_type -> api.backoffice.service.v1.SetAppDownloadRewardConfigRequest
-	64,  // 109: api.backoffice.service.v1.BackofficeWallet.GetAppDownloadRewardConfig:input_type -> api.backoffice.service.v1.GetAppDownloadRewardConfigRequest
+	64,  // 108: api.backoffice.service.v1.BackofficeWallet.SetAppDownloadRewardConfig:input_type -> api.backoffice.service.v1.SetAppDownloadRewardConfigRequest
+	65,  // 109: api.backoffice.service.v1.BackofficeWallet.GetAppDownloadRewardConfig:input_type -> api.backoffice.service.v1.GetAppDownloadRewardConfigRequest
 	54,  // 110: api.backoffice.service.v1.BackofficeWallet.CreatePromoCodeCampaign:input_type -> api.backoffice.service.v1.CreatePromoCodeCampaignRequest
 	55,  // 111: api.backoffice.service.v1.BackofficeWallet.UpdatePromoCodeCampaign:input_type -> api.backoffice.service.v1.UpdatePromoCodeCampaignRequest
 	56,  // 112: api.backoffice.service.v1.BackofficeWallet.UpdatePromoCodeCampaignStatus:input_type -> api.backoffice.service.v1.UpdatePromoCodeCampaignStatusRequest
@@ -6233,79 +6336,81 @@ var file_backoffice_service_v1_backoffice_wallet_proto_depIdxs = []int32{
 	59,  // 115: api.backoffice.service.v1.BackofficeWallet.GenerateOneTimePromoCodes:input_type -> api.backoffice.service.v1.GenerateOneTimePromoCodesRequest
 	60,  // 116: api.backoffice.service.v1.BackofficeWallet.GenerateUniversalPromoCodes:input_type -> api.backoffice.service.v1.GenerateUniversalPromoCodesRequest
 	61,  // 117: api.backoffice.service.v1.BackofficeWallet.ListUniversalCodeUsages:input_type -> api.backoffice.service.v1.ListUniversalCodeUsagesRequest
-	39,  // 118: api.backoffice.service.v1.BackofficeWallet.GetGamificationCurrencyConfig:input_type -> api.backoffice.service.v1.GetGamificationCurrencyConfigRequest
-	40,  // 119: api.backoffice.service.v1.BackofficeWallet.UpdateOperatorCurrencyConfig:input_type -> api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest
-	41,  // 120: api.backoffice.service.v1.BackofficeWallet.UpdateWalletConfig:input_type -> api.backoffice.service.v1.UpdateWalletConfigRequest
-	42,  // 121: api.backoffice.service.v1.BackofficeWallet.DeleteWalletResponsibleGamblingConfig:input_type -> api.backoffice.service.v1.DeleteWalletResponsibleGamblingConfigRequest
-	43,  // 122: api.backoffice.service.v1.BackofficeWallet.ListWalletResponsibleGamblingConfigs:input_type -> api.backoffice.service.v1.ListWalletResponsibleGamblingConfigsRequest
-	44,  // 123: api.backoffice.service.v1.BackofficeWallet.ListCustomerRecords:input_type -> api.backoffice.service.v1.ListCustomerRecordsRequest
-	45,  // 124: api.backoffice.service.v1.BackofficeWallet.ExportCustomerRecords:input_type -> api.backoffice.service.v1.ExportCustomerRecordsRequest
-	46,  // 125: api.backoffice.service.v1.BackofficeWallet.SetFICAThresholdConfig:input_type -> api.backoffice.service.v1.SetFICAThresholdConfigRequest
-	47,  // 126: api.backoffice.service.v1.BackofficeWallet.GetFICAThresholdConfig:input_type -> api.backoffice.service.v1.GetFICAThresholdConfigRequest
-	48,  // 127: api.backoffice.service.v1.BackofficeWallet.ListFICAThresholdTransactions:input_type -> api.backoffice.service.v1.ListFICAThresholdTransactionsRequest
-	49,  // 128: api.backoffice.service.v1.BackofficeWallet.ExportFICAThresholdTransactions:input_type -> api.backoffice.service.v1.ExportFICAThresholdTransactionsRequest
-	50,  // 129: api.backoffice.service.v1.BackofficeWallet.ManualCredit:input_type -> api.backoffice.service.v1.ManualCreditRequest
-	51,  // 130: api.backoffice.service.v1.BackofficeWallet.ManualDebit:input_type -> api.backoffice.service.v1.ManualDebitRequest
-	52,  // 131: api.backoffice.service.v1.BackofficeWallet.ListManualJournalEntries:input_type -> api.backoffice.service.v1.ListManualJournalEntriesRequest
-	53,  // 132: api.backoffice.service.v1.BackofficeWallet.ExportManualJournalEntries:input_type -> api.backoffice.service.v1.ExportManualJournalEntriesRequest
-	62,  // 133: api.backoffice.service.v1.BackofficeWallet.ManualAdjustCreditTurnoverField:input_type -> api.backoffice.service.v1.ManualAdjustCreditTurnoverFieldRequest
-	65,  // 134: api.backoffice.service.v1.BackofficeWallet.ListOperatorWithdrawableAmounts:input_type -> api.backoffice.service.v1.ListOperatorWithdrawableAmountsRequest
-	66,  // 135: api.backoffice.service.v1.BackofficeWallet.GetOperatorWithdrawableAmount:input_type -> api.backoffice.service.v1.BOGetOperatorWithdrawableAmountRequest
-	67,  // 136: api.backoffice.service.v1.BackofficeWallet.ListUserFreeRewards:input_type -> api.backoffice.service.v1.BOListUserFreeRewardsRequest
-	83,  // 137: api.backoffice.service.v1.BackofficeWallet.GetWallets:output_type -> api.wallet.service.v1.GetWalletsResponse
-	2,   // 138: api.backoffice.service.v1.BackofficeWallet.GetWalletCredits:output_type -> api.backoffice.service.v1.GetWalletCreditsResponse
-	4,   // 139: api.backoffice.service.v1.BackofficeWallet.ListWalletBalanceTransactions:output_type -> api.backoffice.service.v1.ListWalletBalanceTransactionsResponse
-	6,   // 140: api.backoffice.service.v1.BackofficeWallet.GetWalletCreditTransactions:output_type -> api.backoffice.service.v1.GetWalletCreditTransactionsResponse
-	8,   // 141: api.backoffice.service.v1.BackofficeWallet.UpdateWallet:output_type -> api.backoffice.service.v1.UpdateWalletResponse
-	11,  // 142: api.backoffice.service.v1.BackofficeWallet.AddWalletCurrency:output_type -> api.backoffice.service.v1.AddWalletCurrencyResponse
-	84,  // 143: api.backoffice.service.v1.BackofficeWallet.ListWalletCurrencies:output_type -> api.wallet.service.v1.ListCurrenciesResponse
-	85,  // 144: api.backoffice.service.v1.BackofficeWallet.UpdateWalletCurrency:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyResponse
-	86,  // 145: api.backoffice.service.v1.BackofficeWallet.ListOperatorBalances:output_type -> api.wallet.service.v1.ListBottomOperatorBalancesResponse
-	87,  // 146: api.backoffice.service.v1.BackofficeWallet.ListCompanyBalances:output_type -> api.wallet.service.v1.ListCompanyOperatorBalancesResponse
-	17,  // 147: api.backoffice.service.v1.BackofficeWallet.GetExchangeRates:output_type -> api.backoffice.service.v1.GetExchangeRatesResponse
-	19,  // 148: api.backoffice.service.v1.BackofficeWallet.OperatorTransfer:output_type -> api.backoffice.service.v1.OperatorTransferResponse
-	21,  // 149: api.backoffice.service.v1.BackofficeWallet.OperatorSwap:output_type -> api.backoffice.service.v1.OperatorSwapResponse
-	23,  // 150: api.backoffice.service.v1.BackofficeWallet.OperatorBalanceFreeze:output_type -> api.backoffice.service.v1.OperatorBalanceFreezeResponse
-	25,  // 151: api.backoffice.service.v1.BackofficeWallet.OperatorBalanceRollback:output_type -> api.backoffice.service.v1.OperatorBalanceRollbackResponse
-	27,  // 152: api.backoffice.service.v1.BackofficeWallet.OperatorBalanceSettle:output_type -> api.backoffice.service.v1.OperatorBalanceSettleResponse
-	29,  // 153: api.backoffice.service.v1.BackofficeWallet.OperatorBalanceAdjust:output_type -> api.backoffice.service.v1.OperatorBalanceAdjustResponse
-	32,  // 154: api.backoffice.service.v1.BackofficeWallet.ListOperatorBalanceTransactions:output_type -> api.backoffice.service.v1.ListOperatorBalanceTransactionsResponse
-	34,  // 155: api.backoffice.service.v1.BackofficeWallet.UpdateOperatorBalance:output_type -> api.backoffice.service.v1.UpdateOperatorBalanceResponse
-	88,  // 156: api.backoffice.service.v1.BackofficeWallet.GetOperatorBalance:output_type -> api.wallet.service.v1.GetOperatorBalanceResponse
-	89,  // 157: api.backoffice.service.v1.BackofficeWallet.SetDepositRewardSequences:output_type -> api.wallet.service.v1.SetDepositRewardSequencesResponse
-	90,  // 158: api.backoffice.service.v1.BackofficeWallet.DeleteDepositRewardSequences:output_type -> api.wallet.service.v1.DeleteDepositRewardSequencesResponse
-	91,  // 159: api.backoffice.service.v1.BackofficeWallet.GetDepositRewardConfig:output_type -> api.wallet.service.v1.GetDepositRewardConfigResponse
-	92,  // 160: api.backoffice.service.v1.BackofficeWallet.SetAppDownloadRewardConfig:output_type -> api.wallet.service.v1.SetAppDownloadRewardConfigResponse
-	93,  // 161: api.backoffice.service.v1.BackofficeWallet.GetAppDownloadRewardConfig:output_type -> api.wallet.service.v1.GetAppDownloadRewardConfigResponse
-	94,  // 162: api.backoffice.service.v1.BackofficeWallet.CreatePromoCodeCampaign:output_type -> api.wallet.service.v1.CreatePromoCodeCampaignResponse
-	95,  // 163: api.backoffice.service.v1.BackofficeWallet.UpdatePromoCodeCampaign:output_type -> api.wallet.service.v1.UpdatePromoCodeCampaignResponse
-	96,  // 164: api.backoffice.service.v1.BackofficeWallet.UpdatePromoCodeCampaignStatus:output_type -> api.wallet.service.v1.UpdatePromoCodeCampaignStatusResponse
-	97,  // 165: api.backoffice.service.v1.BackofficeWallet.ListPromoCodeCampaigns:output_type -> api.wallet.service.v1.ListPromoCodeCampaignsResponse
-	98,  // 166: api.backoffice.service.v1.BackofficeWallet.ListPromoCodeCampaignDetails:output_type -> api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse
-	99,  // 167: api.backoffice.service.v1.BackofficeWallet.GenerateOneTimePromoCodes:output_type -> api.wallet.service.v1.GenerateOneTimePromoCodesResponse
-	100, // 168: api.backoffice.service.v1.BackofficeWallet.GenerateUniversalPromoCodes:output_type -> api.wallet.service.v1.GenerateUniversalPromoCodesResponse
-	101, // 169: api.backoffice.service.v1.BackofficeWallet.ListUniversalCodeUsages:output_type -> api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	102, // 170: api.backoffice.service.v1.BackofficeWallet.GetGamificationCurrencyConfig:output_type -> api.wallet.service.v1.GetGamificationCurrencyConfigResponse
-	103, // 171: api.backoffice.service.v1.BackofficeWallet.UpdateOperatorCurrencyConfig:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse
-	104, // 172: api.backoffice.service.v1.BackofficeWallet.UpdateWalletConfig:output_type -> api.wallet.service.v1.UpdateWalletConfigResponse
-	105, // 173: api.backoffice.service.v1.BackofficeWallet.DeleteWalletResponsibleGamblingConfig:output_type -> api.wallet.service.v1.DeleteResponsibleGamblingConfigResponse
-	106, // 174: api.backoffice.service.v1.BackofficeWallet.ListWalletResponsibleGamblingConfigs:output_type -> api.wallet.service.v1.ListResponsibleGamblingConfigsResponse
-	107, // 175: api.backoffice.service.v1.BackofficeWallet.ListCustomerRecords:output_type -> api.wallet.service.v1.ListCustomerRecordsResponse
-	108, // 176: api.backoffice.service.v1.BackofficeWallet.ExportCustomerRecords:output_type -> api.wallet.service.v1.ExportCustomerRecordsResponse
-	109, // 177: api.backoffice.service.v1.BackofficeWallet.SetFICAThresholdConfig:output_type -> api.wallet.service.v1.SetFICAThresholdConfigResponse
-	110, // 178: api.backoffice.service.v1.BackofficeWallet.GetFICAThresholdConfig:output_type -> api.wallet.service.v1.GetFICAThresholdConfigResponse
-	111, // 179: api.backoffice.service.v1.BackofficeWallet.ListFICAThresholdTransactions:output_type -> api.wallet.service.v1.ListFICAThresholdTransactionsResponse
-	112, // 180: api.backoffice.service.v1.BackofficeWallet.ExportFICAThresholdTransactions:output_type -> api.wallet.service.v1.ExportFICAThresholdTransactionsResponse
-	113, // 181: api.backoffice.service.v1.BackofficeWallet.ManualCredit:output_type -> api.wallet.service.v1.CreditResponse
-	114, // 182: api.backoffice.service.v1.BackofficeWallet.ManualDebit:output_type -> api.wallet.service.v1.DebitResponse
-	115, // 183: api.backoffice.service.v1.BackofficeWallet.ListManualJournalEntries:output_type -> api.wallet.service.v1.ListManualJournalEntriesResponse
-	116, // 184: api.backoffice.service.v1.BackofficeWallet.ExportManualJournalEntries:output_type -> api.wallet.service.v1.ExportManualJournalEntriesResponse
-	117, // 185: api.backoffice.service.v1.BackofficeWallet.ManualAdjustCreditTurnoverField:output_type -> api.wallet.service.v1.ManualAdjustCreditTurnoverFieldResponse
-	118, // 186: api.backoffice.service.v1.BackofficeWallet.ListOperatorWithdrawableAmounts:output_type -> api.wallet.service.v1.ListOperatorWithdrawableAmountsResponse
-	119, // 187: api.backoffice.service.v1.BackofficeWallet.GetOperatorWithdrawableAmount:output_type -> api.wallet.service.v1.GetOperatorWithdrawableAmountResponse
-	120, // 188: api.backoffice.service.v1.BackofficeWallet.ListUserFreeRewards:output_type -> api.wallet.service.v1.ListUserFreeRewardsBOResponse
-	137, // [137:189] is the sub-list for method output_type
-	85,  // [85:137] is the sub-list for method input_type
+	62,  // 118: api.backoffice.service.v1.BackofficeWallet.ExportPromoCodeCampaign:input_type -> api.backoffice.service.v1.ExportPromoCodeCampaignRequest
+	39,  // 119: api.backoffice.service.v1.BackofficeWallet.GetGamificationCurrencyConfig:input_type -> api.backoffice.service.v1.GetGamificationCurrencyConfigRequest
+	40,  // 120: api.backoffice.service.v1.BackofficeWallet.UpdateOperatorCurrencyConfig:input_type -> api.backoffice.service.v1.UpdateOperatorCurrencyConfigRequest
+	41,  // 121: api.backoffice.service.v1.BackofficeWallet.UpdateWalletConfig:input_type -> api.backoffice.service.v1.UpdateWalletConfigRequest
+	42,  // 122: api.backoffice.service.v1.BackofficeWallet.DeleteWalletResponsibleGamblingConfig:input_type -> api.backoffice.service.v1.DeleteWalletResponsibleGamblingConfigRequest
+	43,  // 123: api.backoffice.service.v1.BackofficeWallet.ListWalletResponsibleGamblingConfigs:input_type -> api.backoffice.service.v1.ListWalletResponsibleGamblingConfigsRequest
+	44,  // 124: api.backoffice.service.v1.BackofficeWallet.ListCustomerRecords:input_type -> api.backoffice.service.v1.ListCustomerRecordsRequest
+	45,  // 125: api.backoffice.service.v1.BackofficeWallet.ExportCustomerRecords:input_type -> api.backoffice.service.v1.ExportCustomerRecordsRequest
+	46,  // 126: api.backoffice.service.v1.BackofficeWallet.SetFICAThresholdConfig:input_type -> api.backoffice.service.v1.SetFICAThresholdConfigRequest
+	47,  // 127: api.backoffice.service.v1.BackofficeWallet.GetFICAThresholdConfig:input_type -> api.backoffice.service.v1.GetFICAThresholdConfigRequest
+	48,  // 128: api.backoffice.service.v1.BackofficeWallet.ListFICAThresholdTransactions:input_type -> api.backoffice.service.v1.ListFICAThresholdTransactionsRequest
+	49,  // 129: api.backoffice.service.v1.BackofficeWallet.ExportFICAThresholdTransactions:input_type -> api.backoffice.service.v1.ExportFICAThresholdTransactionsRequest
+	50,  // 130: api.backoffice.service.v1.BackofficeWallet.ManualCredit:input_type -> api.backoffice.service.v1.ManualCreditRequest
+	51,  // 131: api.backoffice.service.v1.BackofficeWallet.ManualDebit:input_type -> api.backoffice.service.v1.ManualDebitRequest
+	52,  // 132: api.backoffice.service.v1.BackofficeWallet.ListManualJournalEntries:input_type -> api.backoffice.service.v1.ListManualJournalEntriesRequest
+	53,  // 133: api.backoffice.service.v1.BackofficeWallet.ExportManualJournalEntries:input_type -> api.backoffice.service.v1.ExportManualJournalEntriesRequest
+	63,  // 134: api.backoffice.service.v1.BackofficeWallet.ManualAdjustCreditTurnoverField:input_type -> api.backoffice.service.v1.ManualAdjustCreditTurnoverFieldRequest
+	66,  // 135: api.backoffice.service.v1.BackofficeWallet.ListOperatorWithdrawableAmounts:input_type -> api.backoffice.service.v1.ListOperatorWithdrawableAmountsRequest
+	67,  // 136: api.backoffice.service.v1.BackofficeWallet.GetOperatorWithdrawableAmount:input_type -> api.backoffice.service.v1.BOGetOperatorWithdrawableAmountRequest
+	68,  // 137: api.backoffice.service.v1.BackofficeWallet.ListUserFreeRewards:input_type -> api.backoffice.service.v1.BOListUserFreeRewardsRequest
+	84,  // 138: api.backoffice.service.v1.BackofficeWallet.GetWallets:output_type -> api.wallet.service.v1.GetWalletsResponse
+	2,   // 139: api.backoffice.service.v1.BackofficeWallet.GetWalletCredits:output_type -> api.backoffice.service.v1.GetWalletCreditsResponse
+	4,   // 140: api.backoffice.service.v1.BackofficeWallet.ListWalletBalanceTransactions:output_type -> api.backoffice.service.v1.ListWalletBalanceTransactionsResponse
+	6,   // 141: api.backoffice.service.v1.BackofficeWallet.GetWalletCreditTransactions:output_type -> api.backoffice.service.v1.GetWalletCreditTransactionsResponse
+	8,   // 142: api.backoffice.service.v1.BackofficeWallet.UpdateWallet:output_type -> api.backoffice.service.v1.UpdateWalletResponse
+	11,  // 143: api.backoffice.service.v1.BackofficeWallet.AddWalletCurrency:output_type -> api.backoffice.service.v1.AddWalletCurrencyResponse
+	85,  // 144: api.backoffice.service.v1.BackofficeWallet.ListWalletCurrencies:output_type -> api.wallet.service.v1.ListCurrenciesResponse
+	86,  // 145: api.backoffice.service.v1.BackofficeWallet.UpdateWalletCurrency:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyResponse
+	87,  // 146: api.backoffice.service.v1.BackofficeWallet.ListOperatorBalances:output_type -> api.wallet.service.v1.ListBottomOperatorBalancesResponse
+	88,  // 147: api.backoffice.service.v1.BackofficeWallet.ListCompanyBalances:output_type -> api.wallet.service.v1.ListCompanyOperatorBalancesResponse
+	17,  // 148: api.backoffice.service.v1.BackofficeWallet.GetExchangeRates:output_type -> api.backoffice.service.v1.GetExchangeRatesResponse
+	19,  // 149: api.backoffice.service.v1.BackofficeWallet.OperatorTransfer:output_type -> api.backoffice.service.v1.OperatorTransferResponse
+	21,  // 150: api.backoffice.service.v1.BackofficeWallet.OperatorSwap:output_type -> api.backoffice.service.v1.OperatorSwapResponse
+	23,  // 151: api.backoffice.service.v1.BackofficeWallet.OperatorBalanceFreeze:output_type -> api.backoffice.service.v1.OperatorBalanceFreezeResponse
+	25,  // 152: api.backoffice.service.v1.BackofficeWallet.OperatorBalanceRollback:output_type -> api.backoffice.service.v1.OperatorBalanceRollbackResponse
+	27,  // 153: api.backoffice.service.v1.BackofficeWallet.OperatorBalanceSettle:output_type -> api.backoffice.service.v1.OperatorBalanceSettleResponse
+	29,  // 154: api.backoffice.service.v1.BackofficeWallet.OperatorBalanceAdjust:output_type -> api.backoffice.service.v1.OperatorBalanceAdjustResponse
+	32,  // 155: api.backoffice.service.v1.BackofficeWallet.ListOperatorBalanceTransactions:output_type -> api.backoffice.service.v1.ListOperatorBalanceTransactionsResponse
+	34,  // 156: api.backoffice.service.v1.BackofficeWallet.UpdateOperatorBalance:output_type -> api.backoffice.service.v1.UpdateOperatorBalanceResponse
+	89,  // 157: api.backoffice.service.v1.BackofficeWallet.GetOperatorBalance:output_type -> api.wallet.service.v1.GetOperatorBalanceResponse
+	90,  // 158: api.backoffice.service.v1.BackofficeWallet.SetDepositRewardSequences:output_type -> api.wallet.service.v1.SetDepositRewardSequencesResponse
+	91,  // 159: api.backoffice.service.v1.BackofficeWallet.DeleteDepositRewardSequences:output_type -> api.wallet.service.v1.DeleteDepositRewardSequencesResponse
+	92,  // 160: api.backoffice.service.v1.BackofficeWallet.GetDepositRewardConfig:output_type -> api.wallet.service.v1.GetDepositRewardConfigResponse
+	93,  // 161: api.backoffice.service.v1.BackofficeWallet.SetAppDownloadRewardConfig:output_type -> api.wallet.service.v1.SetAppDownloadRewardConfigResponse
+	94,  // 162: api.backoffice.service.v1.BackofficeWallet.GetAppDownloadRewardConfig:output_type -> api.wallet.service.v1.GetAppDownloadRewardConfigResponse
+	95,  // 163: api.backoffice.service.v1.BackofficeWallet.CreatePromoCodeCampaign:output_type -> api.wallet.service.v1.CreatePromoCodeCampaignResponse
+	96,  // 164: api.backoffice.service.v1.BackofficeWallet.UpdatePromoCodeCampaign:output_type -> api.wallet.service.v1.UpdatePromoCodeCampaignResponse
+	97,  // 165: api.backoffice.service.v1.BackofficeWallet.UpdatePromoCodeCampaignStatus:output_type -> api.wallet.service.v1.UpdatePromoCodeCampaignStatusResponse
+	98,  // 166: api.backoffice.service.v1.BackofficeWallet.ListPromoCodeCampaigns:output_type -> api.wallet.service.v1.ListPromoCodeCampaignsResponse
+	99,  // 167: api.backoffice.service.v1.BackofficeWallet.ListPromoCodeCampaignDetails:output_type -> api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse
+	100, // 168: api.backoffice.service.v1.BackofficeWallet.GenerateOneTimePromoCodes:output_type -> api.wallet.service.v1.GenerateOneTimePromoCodesResponse
+	101, // 169: api.backoffice.service.v1.BackofficeWallet.GenerateUniversalPromoCodes:output_type -> api.wallet.service.v1.GenerateUniversalPromoCodesResponse
+	102, // 170: api.backoffice.service.v1.BackofficeWallet.ListUniversalCodeUsages:output_type -> api.wallet.service.v1.ListUniversalCodeUsagesResponse
+	103, // 171: api.backoffice.service.v1.BackofficeWallet.ExportPromoCodeCampaign:output_type -> api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	104, // 172: api.backoffice.service.v1.BackofficeWallet.GetGamificationCurrencyConfig:output_type -> api.wallet.service.v1.GetGamificationCurrencyConfigResponse
+	105, // 173: api.backoffice.service.v1.BackofficeWallet.UpdateOperatorCurrencyConfig:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse
+	106, // 174: api.backoffice.service.v1.BackofficeWallet.UpdateWalletConfig:output_type -> api.wallet.service.v1.UpdateWalletConfigResponse
+	107, // 175: api.backoffice.service.v1.BackofficeWallet.DeleteWalletResponsibleGamblingConfig:output_type -> api.wallet.service.v1.DeleteResponsibleGamblingConfigResponse
+	108, // 176: api.backoffice.service.v1.BackofficeWallet.ListWalletResponsibleGamblingConfigs:output_type -> api.wallet.service.v1.ListResponsibleGamblingConfigsResponse
+	109, // 177: api.backoffice.service.v1.BackofficeWallet.ListCustomerRecords:output_type -> api.wallet.service.v1.ListCustomerRecordsResponse
+	110, // 178: api.backoffice.service.v1.BackofficeWallet.ExportCustomerRecords:output_type -> api.wallet.service.v1.ExportCustomerRecordsResponse
+	111, // 179: api.backoffice.service.v1.BackofficeWallet.SetFICAThresholdConfig:output_type -> api.wallet.service.v1.SetFICAThresholdConfigResponse
+	112, // 180: api.backoffice.service.v1.BackofficeWallet.GetFICAThresholdConfig:output_type -> api.wallet.service.v1.GetFICAThresholdConfigResponse
+	113, // 181: api.backoffice.service.v1.BackofficeWallet.ListFICAThresholdTransactions:output_type -> api.wallet.service.v1.ListFICAThresholdTransactionsResponse
+	114, // 182: api.backoffice.service.v1.BackofficeWallet.ExportFICAThresholdTransactions:output_type -> api.wallet.service.v1.ExportFICAThresholdTransactionsResponse
+	115, // 183: api.backoffice.service.v1.BackofficeWallet.ManualCredit:output_type -> api.wallet.service.v1.CreditResponse
+	116, // 184: api.backoffice.service.v1.BackofficeWallet.ManualDebit:output_type -> api.wallet.service.v1.DebitResponse
+	117, // 185: api.backoffice.service.v1.BackofficeWallet.ListManualJournalEntries:output_type -> api.wallet.service.v1.ListManualJournalEntriesResponse
+	118, // 186: api.backoffice.service.v1.BackofficeWallet.ExportManualJournalEntries:output_type -> api.wallet.service.v1.ExportManualJournalEntriesResponse
+	119, // 187: api.backoffice.service.v1.BackofficeWallet.ManualAdjustCreditTurnoverField:output_type -> api.wallet.service.v1.ManualAdjustCreditTurnoverFieldResponse
+	120, // 188: api.backoffice.service.v1.BackofficeWallet.ListOperatorWithdrawableAmounts:output_type -> api.wallet.service.v1.ListOperatorWithdrawableAmountsResponse
+	121, // 189: api.backoffice.service.v1.BackofficeWallet.GetOperatorWithdrawableAmount:output_type -> api.wallet.service.v1.GetOperatorWithdrawableAmountResponse
+	122, // 190: api.backoffice.service.v1.BackofficeWallet.ListUserFreeRewards:output_type -> api.wallet.service.v1.ListUserFreeRewardsBOResponse
+	138, // [138:191] is the sub-list for method output_type
+	85,  // [85:138] is the sub-list for method input_type
 	85,  // [85:85] is the sub-list for extension type_name
 	85,  // [85:85] is the sub-list for extension extendee
 	0,   // [0:85] is the sub-list for field type_name
@@ -6333,16 +6438,17 @@ func file_backoffice_service_v1_backoffice_wallet_proto_init() {
 	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[53].OneofWrappers = []any{}
 	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[57].OneofWrappers = []any{}
 	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[58].OneofWrappers = []any{}
-	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[63].OneofWrappers = []any{}
-	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[65].OneofWrappers = []any{}
-	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[67].OneofWrappers = []any{}
+	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[62].OneofWrappers = []any{}
+	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[64].OneofWrappers = []any{}
+	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[66].OneofWrappers = []any{}
+	file_backoffice_service_v1_backoffice_wallet_proto_msgTypes[68].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_backoffice_service_v1_backoffice_wallet_proto_rawDesc), len(file_backoffice_service_v1_backoffice_wallet_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   73,
+			NumMessages:   74,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/backoffice/service/v1/backoffice_wallet.pb.validate.go
+++ b/backoffice/service/v1/backoffice_wallet.pb.validate.go
@@ -9246,6 +9246,127 @@ var _ interface {
 	ErrorName() string
 } = ListUniversalCodeUsagesRequestValidationError{}
 
+// Validate checks the field values on ExportPromoCodeCampaignRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ExportPromoCodeCampaignRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ExportPromoCodeCampaignRequest with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// ExportPromoCodeCampaignRequestMultiError, or nil if none found.
+func (m *ExportPromoCodeCampaignRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for CampaignId
+
+	// no validation rules for Format
+
+	// no validation rules for TimeZone
+
+	if m.UserId != nil {
+		// no validation rules for UserId
+	}
+
+	if m.Status != nil {
+		// no validation rules for Status
+	}
+
+	if m.Code != nil {
+		// no validation rules for Code
+	}
+
+	if len(errors) > 0 {
+		return ExportPromoCodeCampaignRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// ExportPromoCodeCampaignRequestMultiError is an error wrapping multiple
+// validation errors returned by ExportPromoCodeCampaignRequest.ValidateAll()
+// if the designated constraints aren't met.
+type ExportPromoCodeCampaignRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ExportPromoCodeCampaignRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ExportPromoCodeCampaignRequestMultiError) AllErrors() []error { return m }
+
+// ExportPromoCodeCampaignRequestValidationError is the validation error
+// returned by ExportPromoCodeCampaignRequest.Validate if the designated
+// constraints aren't met.
+type ExportPromoCodeCampaignRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ExportPromoCodeCampaignRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ExportPromoCodeCampaignRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ExportPromoCodeCampaignRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ExportPromoCodeCampaignRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ExportPromoCodeCampaignRequestValidationError) ErrorName() string {
+	return "ExportPromoCodeCampaignRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ExportPromoCodeCampaignRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sExportPromoCodeCampaignRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ExportPromoCodeCampaignRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ExportPromoCodeCampaignRequestValidationError{}
+
 // Validate checks the field values on ManualAdjustCreditTurnoverFieldRequest
 // with the rules defined in the proto definition for this message. If any
 // rules are violated, the first error encountered is returned, or nil if

--- a/backoffice/service/v1/backoffice_wallet.pb.validate.go
+++ b/backoffice/service/v1/backoffice_wallet.pb.validate.go
@@ -9246,22 +9246,22 @@ var _ interface {
 	ErrorName() string
 } = ListUniversalCodeUsagesRequestValidationError{}
 
-// Validate checks the field values on ExportPromoCodeCampaignRequest with the
-// rules defined in the proto definition for this message. If any rules are
+// Validate checks the field values on ExportPromoCodesRequest with the rules
+// defined in the proto definition for this message. If any rules are
 // violated, the first error encountered is returned, or nil if there are no violations.
-func (m *ExportPromoCodeCampaignRequest) Validate() error {
+func (m *ExportPromoCodesRequest) Validate() error {
 	return m.validate(false)
 }
 
-// ValidateAll checks the field values on ExportPromoCodeCampaignRequest with
-// the rules defined in the proto definition for this message. If any rules
-// are violated, the result is a list of violation errors wrapped in
-// ExportPromoCodeCampaignRequestMultiError, or nil if none found.
-func (m *ExportPromoCodeCampaignRequest) ValidateAll() error {
+// ValidateAll checks the field values on ExportPromoCodesRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ExportPromoCodesRequestMultiError, or nil if none found.
+func (m *ExportPromoCodesRequest) ValidateAll() error {
 	return m.validate(true)
 }
 
-func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
+func (m *ExportPromoCodesRequest) validate(all bool) error {
 	if m == nil {
 		return nil
 	}
@@ -9287,19 +9287,19 @@ func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
 	}
 
 	if len(errors) > 0 {
-		return ExportPromoCodeCampaignRequestMultiError(errors)
+		return ExportPromoCodesRequestMultiError(errors)
 	}
 
 	return nil
 }
 
-// ExportPromoCodeCampaignRequestMultiError is an error wrapping multiple
-// validation errors returned by ExportPromoCodeCampaignRequest.ValidateAll()
-// if the designated constraints aren't met.
-type ExportPromoCodeCampaignRequestMultiError []error
+// ExportPromoCodesRequestMultiError is an error wrapping multiple validation
+// errors returned by ExportPromoCodesRequest.ValidateAll() if the designated
+// constraints aren't met.
+type ExportPromoCodesRequestMultiError []error
 
 // Error returns a concatenation of all the error messages it wraps.
-func (m ExportPromoCodeCampaignRequestMultiError) Error() string {
+func (m ExportPromoCodesRequestMultiError) Error() string {
 	msgs := make([]string, 0, len(m))
 	for _, err := range m {
 		msgs = append(msgs, err.Error())
@@ -9308,12 +9308,11 @@ func (m ExportPromoCodeCampaignRequestMultiError) Error() string {
 }
 
 // AllErrors returns a list of validation violation errors.
-func (m ExportPromoCodeCampaignRequestMultiError) AllErrors() []error { return m }
+func (m ExportPromoCodesRequestMultiError) AllErrors() []error { return m }
 
-// ExportPromoCodeCampaignRequestValidationError is the validation error
-// returned by ExportPromoCodeCampaignRequest.Validate if the designated
-// constraints aren't met.
-type ExportPromoCodeCampaignRequestValidationError struct {
+// ExportPromoCodesRequestValidationError is the validation error returned by
+// ExportPromoCodesRequest.Validate if the designated constraints aren't met.
+type ExportPromoCodesRequestValidationError struct {
 	field  string
 	reason string
 	cause  error
@@ -9321,24 +9320,24 @@ type ExportPromoCodeCampaignRequestValidationError struct {
 }
 
 // Field function returns field value.
-func (e ExportPromoCodeCampaignRequestValidationError) Field() string { return e.field }
+func (e ExportPromoCodesRequestValidationError) Field() string { return e.field }
 
 // Reason function returns reason value.
-func (e ExportPromoCodeCampaignRequestValidationError) Reason() string { return e.reason }
+func (e ExportPromoCodesRequestValidationError) Reason() string { return e.reason }
 
 // Cause function returns cause value.
-func (e ExportPromoCodeCampaignRequestValidationError) Cause() error { return e.cause }
+func (e ExportPromoCodesRequestValidationError) Cause() error { return e.cause }
 
 // Key function returns key value.
-func (e ExportPromoCodeCampaignRequestValidationError) Key() bool { return e.key }
+func (e ExportPromoCodesRequestValidationError) Key() bool { return e.key }
 
 // ErrorName returns error name.
-func (e ExportPromoCodeCampaignRequestValidationError) ErrorName() string {
-	return "ExportPromoCodeCampaignRequestValidationError"
+func (e ExportPromoCodesRequestValidationError) ErrorName() string {
+	return "ExportPromoCodesRequestValidationError"
 }
 
 // Error satisfies the builtin error interface
-func (e ExportPromoCodeCampaignRequestValidationError) Error() string {
+func (e ExportPromoCodesRequestValidationError) Error() string {
 	cause := ""
 	if e.cause != nil {
 		cause = fmt.Sprintf(" | caused by: %v", e.cause)
@@ -9350,14 +9349,14 @@ func (e ExportPromoCodeCampaignRequestValidationError) Error() string {
 	}
 
 	return fmt.Sprintf(
-		"invalid %sExportPromoCodeCampaignRequest.%s: %s%s",
+		"invalid %sExportPromoCodesRequest.%s: %s%s",
 		key,
 		e.field,
 		e.reason,
 		cause)
 }
 
-var _ error = ExportPromoCodeCampaignRequestValidationError{}
+var _ error = ExportPromoCodesRequestValidationError{}
 
 var _ interface {
 	Field() string
@@ -9365,7 +9364,7 @@ var _ interface {
 	Key() bool
 	Cause() error
 	ErrorName() string
-} = ExportPromoCodeCampaignRequestValidationError{}
+} = ExportPromoCodesRequestValidationError{}
 
 // Validate checks the field values on ManualAdjustCreditTurnoverFieldRequest
 // with the rules defined in the proto definition for this message. If any

--- a/backoffice/service/v1/backoffice_wallet.proto
+++ b/backoffice/service/v1/backoffice_wallet.proto
@@ -258,6 +258,14 @@ service BackofficeWallet {
 		};
 	}
 
+	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+	rpc ExportPromoCodeCampaign(ExportPromoCodeCampaignRequest) returns (wallet.service.v1.ExportPromoCodeCampaignResponse) {
+		option (google.api.http) = {
+			post: "/v1/backoffice/wallet/promo-code/campaign/export"
+			body: "*"
+		};
+	}
+
 	// GetGamificationCurrencyConfig returns the currency config and the deduction order config based on currency and operator context
 	rpc GetGamificationCurrencyConfig(GetGamificationCurrencyConfigRequest) returns (wallet.service.v1.GetGamificationCurrencyConfigResponse) {
 		option (google.api.http) = {
@@ -989,6 +997,19 @@ message GenerateUniversalPromoCodesRequest {
 // List Universal Code Usages
 message ListUniversalCodeUsagesRequest {
 	int64 campaign_id = 1;
+}
+
+// Export Promo Code Campaign
+message ExportPromoCodeCampaignRequest {
+	int64 campaign_id = 1;
+	// "csv", "excel", or "pdf"
+	string format = 2;
+	// e.g. "UTC+0", "UTC+8"
+	string time_zone = 3;
+	optional int64 user_id = 4;
+	// "used" or "unused" (one_time only)
+	optional string status = 5;
+	optional string code = 6;
 }
 
 // ManualAdjustCreditTurnoverField adjusts a credit's turnover or threshold value

--- a/backoffice/service/v1/backoffice_wallet.proto
+++ b/backoffice/service/v1/backoffice_wallet.proto
@@ -258,8 +258,8 @@ service BackofficeWallet {
 		};
 	}
 
-	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-	rpc ExportPromoCodeCampaign(ExportPromoCodeCampaignRequest) returns (wallet.service.v1.ExportPromoCodeCampaignResponse) {
+	// ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+	rpc ExportPromoCodes(ExportPromoCodesRequest) returns (wallet.service.v1.ExportPromoCodesResponse) {
 		option (google.api.http) = {
 			post: "/v1/backoffice/wallet/promo-code/campaign/export"
 			body: "*"
@@ -999,8 +999,8 @@ message ListUniversalCodeUsagesRequest {
 	int64 campaign_id = 1;
 }
 
-// Export Promo Code Campaign
-message ExportPromoCodeCampaignRequest {
+// Export Promo Codes
+message ExportPromoCodesRequest {
 	int64 campaign_id = 1;
 	// "csv", "excel", or "pdf"
 	string format = 2;

--- a/backoffice/service/v1/backoffice_wallet_grpc.pb.go
+++ b/backoffice/service/v1/backoffice_wallet_grpc.pb.go
@@ -53,6 +53,7 @@ const (
 	BackofficeWallet_GenerateOneTimePromoCodes_FullMethodName             = "/api.backoffice.service.v1.BackofficeWallet/GenerateOneTimePromoCodes"
 	BackofficeWallet_GenerateUniversalPromoCodes_FullMethodName           = "/api.backoffice.service.v1.BackofficeWallet/GenerateUniversalPromoCodes"
 	BackofficeWallet_ListUniversalCodeUsages_FullMethodName               = "/api.backoffice.service.v1.BackofficeWallet/ListUniversalCodeUsages"
+	BackofficeWallet_ExportPromoCodeCampaign_FullMethodName               = "/api.backoffice.service.v1.BackofficeWallet/ExportPromoCodeCampaign"
 	BackofficeWallet_GetGamificationCurrencyConfig_FullMethodName         = "/api.backoffice.service.v1.BackofficeWallet/GetGamificationCurrencyConfig"
 	BackofficeWallet_UpdateOperatorCurrencyConfig_FullMethodName          = "/api.backoffice.service.v1.BackofficeWallet/UpdateOperatorCurrencyConfig"
 	BackofficeWallet_UpdateWalletConfig_FullMethodName                    = "/api.backoffice.service.v1.BackofficeWallet/UpdateWalletConfig"
@@ -144,6 +145,8 @@ type BackofficeWalletClient interface {
 	GenerateUniversalPromoCodes(ctx context.Context, in *GenerateUniversalPromoCodesRequest, opts ...grpc.CallOption) (*v1.GenerateUniversalPromoCodesResponse, error)
 	// ListUniversalCodeUsages lists the usages of a universal campaign
 	ListUniversalCodeUsages(ctx context.Context, in *ListUniversalCodeUsagesRequest, opts ...grpc.CallOption) (*v1.ListUniversalCodeUsagesResponse, error)
+	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+	ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...grpc.CallOption) (*v1.ExportPromoCodeCampaignResponse, error)
 	// GetGamificationCurrencyConfig returns the currency config and the deduction order config based on currency and operator context
 	GetGamificationCurrencyConfig(ctx context.Context, in *GetGamificationCurrencyConfigRequest, opts ...grpc.CallOption) (*v1.GetGamificationCurrencyConfigResponse, error)
 	// UpdateOperatorCurrencyConfig updates the config of a operator and its currency
@@ -522,6 +525,16 @@ func (c *backofficeWalletClient) ListUniversalCodeUsages(ctx context.Context, in
 	return out, nil
 }
 
+func (c *backofficeWalletClient) ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...grpc.CallOption) (*v1.ExportPromoCodeCampaignResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(v1.ExportPromoCodeCampaignResponse)
+	err := c.cc.Invoke(ctx, BackofficeWallet_ExportPromoCodeCampaign_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *backofficeWalletClient) GetGamificationCurrencyConfig(ctx context.Context, in *GetGamificationCurrencyConfigRequest, opts ...grpc.CallOption) (*v1.GetGamificationCurrencyConfigResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(v1.GetGamificationCurrencyConfigResponse)
@@ -782,6 +795,8 @@ type BackofficeWalletServer interface {
 	GenerateUniversalPromoCodes(context.Context, *GenerateUniversalPromoCodesRequest) (*v1.GenerateUniversalPromoCodesResponse, error)
 	// ListUniversalCodeUsages lists the usages of a universal campaign
 	ListUniversalCodeUsages(context.Context, *ListUniversalCodeUsagesRequest) (*v1.ListUniversalCodeUsagesResponse, error)
+	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+	ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*v1.ExportPromoCodeCampaignResponse, error)
 	// GetGamificationCurrencyConfig returns the currency config and the deduction order config based on currency and operator context
 	GetGamificationCurrencyConfig(context.Context, *GetGamificationCurrencyConfigRequest) (*v1.GetGamificationCurrencyConfigResponse, error)
 	// UpdateOperatorCurrencyConfig updates the config of a operator and its currency
@@ -928,6 +943,9 @@ func (UnimplementedBackofficeWalletServer) GenerateUniversalPromoCodes(context.C
 }
 func (UnimplementedBackofficeWalletServer) ListUniversalCodeUsages(context.Context, *ListUniversalCodeUsagesRequest) (*v1.ListUniversalCodeUsagesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListUniversalCodeUsages not implemented")
+}
+func (UnimplementedBackofficeWalletServer) ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*v1.ExportPromoCodeCampaignResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExportPromoCodeCampaign not implemented")
 }
 func (UnimplementedBackofficeWalletServer) GetGamificationCurrencyConfig(context.Context, *GetGamificationCurrencyConfigRequest) (*v1.GetGamificationCurrencyConfigResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetGamificationCurrencyConfig not implemented")
@@ -1601,6 +1619,24 @@ func _BackofficeWallet_ListUniversalCodeUsages_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BackofficeWallet_ExportPromoCodeCampaign_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExportPromoCodeCampaignRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BackofficeWalletServer).ExportPromoCodeCampaign(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BackofficeWallet_ExportPromoCodeCampaign_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BackofficeWalletServer).ExportPromoCodeCampaign(ctx, req.(*ExportPromoCodeCampaignRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _BackofficeWallet_GetGamificationCurrencyConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetGamificationCurrencyConfigRequest)
 	if err := dec(in); err != nil {
@@ -2081,6 +2117,10 @@ var BackofficeWallet_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListUniversalCodeUsages",
 			Handler:    _BackofficeWallet_ListUniversalCodeUsages_Handler,
+		},
+		{
+			MethodName: "ExportPromoCodeCampaign",
+			Handler:    _BackofficeWallet_ExportPromoCodeCampaign_Handler,
 		},
 		{
 			MethodName: "GetGamificationCurrencyConfig",

--- a/backoffice/service/v1/backoffice_wallet_grpc.pb.go
+++ b/backoffice/service/v1/backoffice_wallet_grpc.pb.go
@@ -53,7 +53,7 @@ const (
 	BackofficeWallet_GenerateOneTimePromoCodes_FullMethodName             = "/api.backoffice.service.v1.BackofficeWallet/GenerateOneTimePromoCodes"
 	BackofficeWallet_GenerateUniversalPromoCodes_FullMethodName           = "/api.backoffice.service.v1.BackofficeWallet/GenerateUniversalPromoCodes"
 	BackofficeWallet_ListUniversalCodeUsages_FullMethodName               = "/api.backoffice.service.v1.BackofficeWallet/ListUniversalCodeUsages"
-	BackofficeWallet_ExportPromoCodeCampaign_FullMethodName               = "/api.backoffice.service.v1.BackofficeWallet/ExportPromoCodeCampaign"
+	BackofficeWallet_ExportPromoCodes_FullMethodName                      = "/api.backoffice.service.v1.BackofficeWallet/ExportPromoCodes"
 	BackofficeWallet_GetGamificationCurrencyConfig_FullMethodName         = "/api.backoffice.service.v1.BackofficeWallet/GetGamificationCurrencyConfig"
 	BackofficeWallet_UpdateOperatorCurrencyConfig_FullMethodName          = "/api.backoffice.service.v1.BackofficeWallet/UpdateOperatorCurrencyConfig"
 	BackofficeWallet_UpdateWalletConfig_FullMethodName                    = "/api.backoffice.service.v1.BackofficeWallet/UpdateWalletConfig"
@@ -145,8 +145,8 @@ type BackofficeWalletClient interface {
 	GenerateUniversalPromoCodes(ctx context.Context, in *GenerateUniversalPromoCodesRequest, opts ...grpc.CallOption) (*v1.GenerateUniversalPromoCodesResponse, error)
 	// ListUniversalCodeUsages lists the usages of a universal campaign
 	ListUniversalCodeUsages(ctx context.Context, in *ListUniversalCodeUsagesRequest, opts ...grpc.CallOption) (*v1.ListUniversalCodeUsagesResponse, error)
-	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-	ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...grpc.CallOption) (*v1.ExportPromoCodeCampaignResponse, error)
+	// ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+	ExportPromoCodes(ctx context.Context, in *ExportPromoCodesRequest, opts ...grpc.CallOption) (*v1.ExportPromoCodesResponse, error)
 	// GetGamificationCurrencyConfig returns the currency config and the deduction order config based on currency and operator context
 	GetGamificationCurrencyConfig(ctx context.Context, in *GetGamificationCurrencyConfigRequest, opts ...grpc.CallOption) (*v1.GetGamificationCurrencyConfigResponse, error)
 	// UpdateOperatorCurrencyConfig updates the config of a operator and its currency
@@ -525,10 +525,10 @@ func (c *backofficeWalletClient) ListUniversalCodeUsages(ctx context.Context, in
 	return out, nil
 }
 
-func (c *backofficeWalletClient) ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...grpc.CallOption) (*v1.ExportPromoCodeCampaignResponse, error) {
+func (c *backofficeWalletClient) ExportPromoCodes(ctx context.Context, in *ExportPromoCodesRequest, opts ...grpc.CallOption) (*v1.ExportPromoCodesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(v1.ExportPromoCodeCampaignResponse)
-	err := c.cc.Invoke(ctx, BackofficeWallet_ExportPromoCodeCampaign_FullMethodName, in, out, cOpts...)
+	out := new(v1.ExportPromoCodesResponse)
+	err := c.cc.Invoke(ctx, BackofficeWallet_ExportPromoCodes_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -795,8 +795,8 @@ type BackofficeWalletServer interface {
 	GenerateUniversalPromoCodes(context.Context, *GenerateUniversalPromoCodesRequest) (*v1.GenerateUniversalPromoCodesResponse, error)
 	// ListUniversalCodeUsages lists the usages of a universal campaign
 	ListUniversalCodeUsages(context.Context, *ListUniversalCodeUsagesRequest) (*v1.ListUniversalCodeUsagesResponse, error)
-	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-	ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*v1.ExportPromoCodeCampaignResponse, error)
+	// ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+	ExportPromoCodes(context.Context, *ExportPromoCodesRequest) (*v1.ExportPromoCodesResponse, error)
 	// GetGamificationCurrencyConfig returns the currency config and the deduction order config based on currency and operator context
 	GetGamificationCurrencyConfig(context.Context, *GetGamificationCurrencyConfigRequest) (*v1.GetGamificationCurrencyConfigResponse, error)
 	// UpdateOperatorCurrencyConfig updates the config of a operator and its currency
@@ -944,8 +944,8 @@ func (UnimplementedBackofficeWalletServer) GenerateUniversalPromoCodes(context.C
 func (UnimplementedBackofficeWalletServer) ListUniversalCodeUsages(context.Context, *ListUniversalCodeUsagesRequest) (*v1.ListUniversalCodeUsagesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListUniversalCodeUsages not implemented")
 }
-func (UnimplementedBackofficeWalletServer) ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*v1.ExportPromoCodeCampaignResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method ExportPromoCodeCampaign not implemented")
+func (UnimplementedBackofficeWalletServer) ExportPromoCodes(context.Context, *ExportPromoCodesRequest) (*v1.ExportPromoCodesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExportPromoCodes not implemented")
 }
 func (UnimplementedBackofficeWalletServer) GetGamificationCurrencyConfig(context.Context, *GetGamificationCurrencyConfigRequest) (*v1.GetGamificationCurrencyConfigResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetGamificationCurrencyConfig not implemented")
@@ -1619,20 +1619,20 @@ func _BackofficeWallet_ListUniversalCodeUsages_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
-func _BackofficeWallet_ExportPromoCodeCampaign_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ExportPromoCodeCampaignRequest)
+func _BackofficeWallet_ExportPromoCodes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExportPromoCodesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(BackofficeWalletServer).ExportPromoCodeCampaign(ctx, in)
+		return srv.(BackofficeWalletServer).ExportPromoCodes(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: BackofficeWallet_ExportPromoCodeCampaign_FullMethodName,
+		FullMethod: BackofficeWallet_ExportPromoCodes_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(BackofficeWalletServer).ExportPromoCodeCampaign(ctx, req.(*ExportPromoCodeCampaignRequest))
+		return srv.(BackofficeWalletServer).ExportPromoCodes(ctx, req.(*ExportPromoCodesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2119,8 +2119,8 @@ var BackofficeWallet_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _BackofficeWallet_ListUniversalCodeUsages_Handler,
 		},
 		{
-			MethodName: "ExportPromoCodeCampaign",
-			Handler:    _BackofficeWallet_ExportPromoCodeCampaign_Handler,
+			MethodName: "ExportPromoCodes",
+			Handler:    _BackofficeWallet_ExportPromoCodes_Handler,
 		},
 		{
 			MethodName: "GetGamificationCurrencyConfig",

--- a/backoffice/service/v1/backoffice_wallet_http.pb.go
+++ b/backoffice/service/v1/backoffice_wallet_http.pb.go
@@ -27,6 +27,7 @@ const OperationBackofficeWalletDeleteWalletResponsibleGamblingConfig = "/api.bac
 const OperationBackofficeWalletExportCustomerRecords = "/api.backoffice.service.v1.BackofficeWallet/ExportCustomerRecords"
 const OperationBackofficeWalletExportFICAThresholdTransactions = "/api.backoffice.service.v1.BackofficeWallet/ExportFICAThresholdTransactions"
 const OperationBackofficeWalletExportManualJournalEntries = "/api.backoffice.service.v1.BackofficeWallet/ExportManualJournalEntries"
+const OperationBackofficeWalletExportPromoCodeCampaign = "/api.backoffice.service.v1.BackofficeWallet/ExportPromoCodeCampaign"
 const OperationBackofficeWalletGenerateOneTimePromoCodes = "/api.backoffice.service.v1.BackofficeWallet/GenerateOneTimePromoCodes"
 const OperationBackofficeWalletGenerateUniversalPromoCodes = "/api.backoffice.service.v1.BackofficeWallet/GenerateUniversalPromoCodes"
 const OperationBackofficeWalletGetAppDownloadRewardConfig = "/api.backoffice.service.v1.BackofficeWallet/GetAppDownloadRewardConfig"
@@ -88,6 +89,8 @@ type BackofficeWalletHTTPServer interface {
 	ExportFICAThresholdTransactions(context.Context, *ExportFICAThresholdTransactionsRequest) (*v1.ExportFICAThresholdTransactionsResponse, error)
 	// ExportManualJournalEntries ExportManualJournalEntries creates a task to exports manual journal entries for all users
 	ExportManualJournalEntries(context.Context, *ExportManualJournalEntriesRequest) (*v1.ExportManualJournalEntriesResponse, error)
+	// ExportPromoCodeCampaign ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+	ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*v1.ExportPromoCodeCampaignResponse, error)
 	// GenerateOneTimePromoCodes GenerateOneTimePromoCodes generates codes for a one_time campaign
 	GenerateOneTimePromoCodes(context.Context, *GenerateOneTimePromoCodesRequest) (*v1.GenerateOneTimePromoCodesResponse, error)
 	// GenerateUniversalPromoCodes GenerateUniversalPromoCodes generates codes for a universal campaign
@@ -215,6 +218,7 @@ func RegisterBackofficeWalletHTTPServer(s *http.Server, srv BackofficeWalletHTTP
 	r.POST("/v1/backoffice/wallet/promo-code/one-time/codes/generate", _BackofficeWallet_GenerateOneTimePromoCodes0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/promo-code/universal/codes/generate", _BackofficeWallet_GenerateUniversalPromoCodes0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/promo-code/universal/usages/list", _BackofficeWallet_ListUniversalCodeUsages0_HTTP_Handler(srv))
+	r.POST("/v1/backoffice/wallet/promo-code/campaign/export", _BackofficeWallet_ExportPromoCodeCampaign0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/gamification/get", _BackofficeWallet_GetGamificationCurrencyConfig0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/currency/config/update", _BackofficeWallet_UpdateOperatorCurrencyConfig0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/config/update", _BackofficeWallet_UpdateWalletConfig0_HTTP_Handler(srv))
@@ -962,6 +966,28 @@ func _BackofficeWallet_ListUniversalCodeUsages0_HTTP_Handler(srv BackofficeWalle
 	}
 }
 
+func _BackofficeWallet_ExportPromoCodeCampaign0_HTTP_Handler(srv BackofficeWalletHTTPServer) func(ctx http.Context) error {
+	return func(ctx http.Context) error {
+		var in ExportPromoCodeCampaignRequest
+		if err := ctx.Bind(&in); err != nil {
+			return err
+		}
+		if err := ctx.BindQuery(&in); err != nil {
+			return err
+		}
+		http.SetOperation(ctx, OperationBackofficeWalletExportPromoCodeCampaign)
+		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
+			return srv.ExportPromoCodeCampaign(ctx, req.(*ExportPromoCodeCampaignRequest))
+		})
+		out, err := h(ctx, &in)
+		if err != nil {
+			return err
+		}
+		reply := out.(*v1.ExportPromoCodeCampaignResponse)
+		return ctx.Result(200, reply)
+	}
+}
+
 func _BackofficeWallet_GetGamificationCurrencyConfig0_HTTP_Handler(srv BackofficeWalletHTTPServer) func(ctx http.Context) error {
 	return func(ctx http.Context) error {
 		var in GetGamificationCurrencyConfigRequest
@@ -1395,6 +1421,8 @@ type BackofficeWalletHTTPClient interface {
 	ExportFICAThresholdTransactions(ctx context.Context, req *ExportFICAThresholdTransactionsRequest, opts ...http.CallOption) (rsp *v1.ExportFICAThresholdTransactionsResponse, err error)
 	// ExportManualJournalEntries ExportManualJournalEntries creates a task to exports manual journal entries for all users
 	ExportManualJournalEntries(ctx context.Context, req *ExportManualJournalEntriesRequest, opts ...http.CallOption) (rsp *v1.ExportManualJournalEntriesResponse, err error)
+	// ExportPromoCodeCampaign ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+	ExportPromoCodeCampaign(ctx context.Context, req *ExportPromoCodeCampaignRequest, opts ...http.CallOption) (rsp *v1.ExportPromoCodeCampaignResponse, err error)
 	// GenerateOneTimePromoCodes GenerateOneTimePromoCodes generates codes for a one_time campaign
 	GenerateOneTimePromoCodes(ctx context.Context, req *GenerateOneTimePromoCodesRequest, opts ...http.CallOption) (rsp *v1.GenerateOneTimePromoCodesResponse, err error)
 	// GenerateUniversalPromoCodes GenerateUniversalPromoCodes generates codes for a universal campaign
@@ -1585,6 +1613,20 @@ func (c *BackofficeWalletHTTPClientImpl) ExportManualJournalEntries(ctx context.
 	pattern := "/v1/backoffice/wallet/manual/journal-entries/export"
 	path := binding.EncodeURL(pattern, in, false)
 	opts = append(opts, http.Operation(OperationBackofficeWalletExportManualJournalEntries))
+	opts = append(opts, http.PathTemplate(pattern))
+	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ExportPromoCodeCampaign ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+func (c *BackofficeWalletHTTPClientImpl) ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...http.CallOption) (*v1.ExportPromoCodeCampaignResponse, error) {
+	var out v1.ExportPromoCodeCampaignResponse
+	pattern := "/v1/backoffice/wallet/promo-code/campaign/export"
+	path := binding.EncodeURL(pattern, in, false)
+	opts = append(opts, http.Operation(OperationBackofficeWalletExportPromoCodeCampaign))
 	opts = append(opts, http.PathTemplate(pattern))
 	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
 	if err != nil {

--- a/backoffice/service/v1/backoffice_wallet_http.pb.go
+++ b/backoffice/service/v1/backoffice_wallet_http.pb.go
@@ -27,7 +27,7 @@ const OperationBackofficeWalletDeleteWalletResponsibleGamblingConfig = "/api.bac
 const OperationBackofficeWalletExportCustomerRecords = "/api.backoffice.service.v1.BackofficeWallet/ExportCustomerRecords"
 const OperationBackofficeWalletExportFICAThresholdTransactions = "/api.backoffice.service.v1.BackofficeWallet/ExportFICAThresholdTransactions"
 const OperationBackofficeWalletExportManualJournalEntries = "/api.backoffice.service.v1.BackofficeWallet/ExportManualJournalEntries"
-const OperationBackofficeWalletExportPromoCodeCampaign = "/api.backoffice.service.v1.BackofficeWallet/ExportPromoCodeCampaign"
+const OperationBackofficeWalletExportPromoCodes = "/api.backoffice.service.v1.BackofficeWallet/ExportPromoCodes"
 const OperationBackofficeWalletGenerateOneTimePromoCodes = "/api.backoffice.service.v1.BackofficeWallet/GenerateOneTimePromoCodes"
 const OperationBackofficeWalletGenerateUniversalPromoCodes = "/api.backoffice.service.v1.BackofficeWallet/GenerateUniversalPromoCodes"
 const OperationBackofficeWalletGetAppDownloadRewardConfig = "/api.backoffice.service.v1.BackofficeWallet/GetAppDownloadRewardConfig"
@@ -89,8 +89,8 @@ type BackofficeWalletHTTPServer interface {
 	ExportFICAThresholdTransactions(context.Context, *ExportFICAThresholdTransactionsRequest) (*v1.ExportFICAThresholdTransactionsResponse, error)
 	// ExportManualJournalEntries ExportManualJournalEntries creates a task to exports manual journal entries for all users
 	ExportManualJournalEntries(context.Context, *ExportManualJournalEntriesRequest) (*v1.ExportManualJournalEntriesResponse, error)
-	// ExportPromoCodeCampaign ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-	ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*v1.ExportPromoCodeCampaignResponse, error)
+	// ExportPromoCodes ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+	ExportPromoCodes(context.Context, *ExportPromoCodesRequest) (*v1.ExportPromoCodesResponse, error)
 	// GenerateOneTimePromoCodes GenerateOneTimePromoCodes generates codes for a one_time campaign
 	GenerateOneTimePromoCodes(context.Context, *GenerateOneTimePromoCodesRequest) (*v1.GenerateOneTimePromoCodesResponse, error)
 	// GenerateUniversalPromoCodes GenerateUniversalPromoCodes generates codes for a universal campaign
@@ -218,7 +218,7 @@ func RegisterBackofficeWalletHTTPServer(s *http.Server, srv BackofficeWalletHTTP
 	r.POST("/v1/backoffice/wallet/promo-code/one-time/codes/generate", _BackofficeWallet_GenerateOneTimePromoCodes0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/promo-code/universal/codes/generate", _BackofficeWallet_GenerateUniversalPromoCodes0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/promo-code/universal/usages/list", _BackofficeWallet_ListUniversalCodeUsages0_HTTP_Handler(srv))
-	r.POST("/v1/backoffice/wallet/promo-code/campaign/export", _BackofficeWallet_ExportPromoCodeCampaign0_HTTP_Handler(srv))
+	r.POST("/v1/backoffice/wallet/promo-code/campaign/export", _BackofficeWallet_ExportPromoCodes0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/gamification/get", _BackofficeWallet_GetGamificationCurrencyConfig0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/currency/config/update", _BackofficeWallet_UpdateOperatorCurrencyConfig0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/wallet/config/update", _BackofficeWallet_UpdateWalletConfig0_HTTP_Handler(srv))
@@ -966,24 +966,24 @@ func _BackofficeWallet_ListUniversalCodeUsages0_HTTP_Handler(srv BackofficeWalle
 	}
 }
 
-func _BackofficeWallet_ExportPromoCodeCampaign0_HTTP_Handler(srv BackofficeWalletHTTPServer) func(ctx http.Context) error {
+func _BackofficeWallet_ExportPromoCodes0_HTTP_Handler(srv BackofficeWalletHTTPServer) func(ctx http.Context) error {
 	return func(ctx http.Context) error {
-		var in ExportPromoCodeCampaignRequest
+		var in ExportPromoCodesRequest
 		if err := ctx.Bind(&in); err != nil {
 			return err
 		}
 		if err := ctx.BindQuery(&in); err != nil {
 			return err
 		}
-		http.SetOperation(ctx, OperationBackofficeWalletExportPromoCodeCampaign)
+		http.SetOperation(ctx, OperationBackofficeWalletExportPromoCodes)
 		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
-			return srv.ExportPromoCodeCampaign(ctx, req.(*ExportPromoCodeCampaignRequest))
+			return srv.ExportPromoCodes(ctx, req.(*ExportPromoCodesRequest))
 		})
 		out, err := h(ctx, &in)
 		if err != nil {
 			return err
 		}
-		reply := out.(*v1.ExportPromoCodeCampaignResponse)
+		reply := out.(*v1.ExportPromoCodesResponse)
 		return ctx.Result(200, reply)
 	}
 }
@@ -1421,8 +1421,8 @@ type BackofficeWalletHTTPClient interface {
 	ExportFICAThresholdTransactions(ctx context.Context, req *ExportFICAThresholdTransactionsRequest, opts ...http.CallOption) (rsp *v1.ExportFICAThresholdTransactionsResponse, err error)
 	// ExportManualJournalEntries ExportManualJournalEntries creates a task to exports manual journal entries for all users
 	ExportManualJournalEntries(ctx context.Context, req *ExportManualJournalEntriesRequest, opts ...http.CallOption) (rsp *v1.ExportManualJournalEntriesResponse, err error)
-	// ExportPromoCodeCampaign ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-	ExportPromoCodeCampaign(ctx context.Context, req *ExportPromoCodeCampaignRequest, opts ...http.CallOption) (rsp *v1.ExportPromoCodeCampaignResponse, err error)
+	// ExportPromoCodes ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+	ExportPromoCodes(ctx context.Context, req *ExportPromoCodesRequest, opts ...http.CallOption) (rsp *v1.ExportPromoCodesResponse, err error)
 	// GenerateOneTimePromoCodes GenerateOneTimePromoCodes generates codes for a one_time campaign
 	GenerateOneTimePromoCodes(ctx context.Context, req *GenerateOneTimePromoCodesRequest, opts ...http.CallOption) (rsp *v1.GenerateOneTimePromoCodesResponse, err error)
 	// GenerateUniversalPromoCodes GenerateUniversalPromoCodes generates codes for a universal campaign
@@ -1621,12 +1621,12 @@ func (c *BackofficeWalletHTTPClientImpl) ExportManualJournalEntries(ctx context.
 	return &out, nil
 }
 
-// ExportPromoCodeCampaign ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-func (c *BackofficeWalletHTTPClientImpl) ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...http.CallOption) (*v1.ExportPromoCodeCampaignResponse, error) {
-	var out v1.ExportPromoCodeCampaignResponse
+// ExportPromoCodes ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+func (c *BackofficeWalletHTTPClientImpl) ExportPromoCodes(ctx context.Context, in *ExportPromoCodesRequest, opts ...http.CallOption) (*v1.ExportPromoCodesResponse, error) {
+	var out v1.ExportPromoCodesResponse
 	pattern := "/v1/backoffice/wallet/promo-code/campaign/export"
 	path := binding.EncodeURL(pattern, in, false)
-	opts = append(opts, http.Operation(OperationBackofficeWalletExportPromoCodeCampaign))
+	opts = append(opts, http.Operation(OperationBackofficeWalletExportPromoCodes))
 	opts = append(opts, http.PathTemplate(pattern))
 	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
 	if err != nil {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8959,13 +8959,13 @@ paths:
         post:
             tags:
                 - BackofficeWallet
-            description: ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-            operationId: BackofficeWallet_ExportPromoCodeCampaign
+            description: ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+            operationId: BackofficeWallet_ExportPromoCodes
             requestBody:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/api.backoffice.service.v1.ExportPromoCodeCampaignRequest'
+                            $ref: '#/components/schemas/api.backoffice.service.v1.ExportPromoCodesRequest'
                 required: true
             responses:
                 "200":
@@ -8973,7 +8973,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/api.wallet.service.v1.ExportPromoCodeCampaignResponse'
+                                $ref: '#/components/schemas/api.wallet.service.v1.ExportPromoCodesResponse'
     /v1/backoffice/wallet/promo-code/campaign/status/update:
         post:
             tags:
@@ -17095,7 +17095,7 @@ components:
                     type: string
                 operatorContextFilters:
                     $ref: '#/components/schemas/api.common.OperatorContextFilters'
-        api.backoffice.service.v1.ExportPromoCodeCampaignRequest:
+        api.backoffice.service.v1.ExportPromoCodesRequest:
             type: object
             properties:
                 campaignId:
@@ -17113,7 +17113,7 @@ components:
                     description: '"used" or "unused" (one_time only)'
                 code:
                     type: string
-            description: Export Promo Code Campaign
+            description: Export Promo Codes
         api.backoffice.service.v1.ExportSevRequest:
             type: object
             properties:
@@ -33517,7 +33517,7 @@ components:
             properties:
                 taskId:
                     type: string
-        api.wallet.service.v1.ExportPromoCodeCampaignResponse:
+        api.wallet.service.v1.ExportPromoCodesResponse:
             type: object
             properties:
                 taskId:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8955,6 +8955,25 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse'
+    /v1/backoffice/wallet/promo-code/campaign/export:
+        post:
+            tags:
+                - BackofficeWallet
+            description: ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+            operationId: BackofficeWallet_ExportPromoCodeCampaign
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/api.backoffice.service.v1.ExportPromoCodeCampaignRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/api.wallet.service.v1.ExportPromoCodeCampaignResponse'
     /v1/backoffice/wallet/promo-code/campaign/status/update:
         post:
             tags:
@@ -17076,6 +17095,25 @@ components:
                     type: string
                 operatorContextFilters:
                     $ref: '#/components/schemas/api.common.OperatorContextFilters'
+        api.backoffice.service.v1.ExportPromoCodeCampaignRequest:
+            type: object
+            properties:
+                campaignId:
+                    type: string
+                format:
+                    type: string
+                    description: '"csv", "excel", or "pdf"'
+                timeZone:
+                    type: string
+                    description: e.g. "UTC+0", "UTC+8"
+                userId:
+                    type: string
+                status:
+                    type: string
+                    description: '"used" or "unused" (one_time only)'
+                code:
+                    type: string
+            description: Export Promo Code Campaign
         api.backoffice.service.v1.ExportSevRequest:
             type: object
             properties:
@@ -33475,6 +33513,11 @@ components:
                 taskId:
                     type: string
         api.wallet.service.v1.ExportManualJournalEntriesResponse:
+            type: object
+            properties:
+                taskId:
+                    type: string
+        api.wallet.service.v1.ExportPromoCodeCampaignResponse:
             type: object
             properties:
                 taskId:

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -24,6 +24,7 @@ const (
 	REPORT_EXPORT_TYPE_AFFILIATE_USERS             = "affiliate_users"
 	REPORT_EXPORT_TYPE_GAME_DATA                   = "game_data"
 	REPORT_EXPORT_TYPE_USER_LIST                   = "user_list"
+	REPORT_EXPORT_TYPE_PROMO_CODE_CAMPAIGN         = "promo_code_campaign"
 )
 
 type ReportExportPayload struct {

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -24,7 +24,7 @@ const (
 	REPORT_EXPORT_TYPE_AFFILIATE_USERS             = "affiliate_users"
 	REPORT_EXPORT_TYPE_GAME_DATA                   = "game_data"
 	REPORT_EXPORT_TYPE_USER_LIST                   = "user_list"
-	REPORT_EXPORT_TYPE_PROMO_CODE_CAMPAIGN         = "promo_code_campaign"
+	REPORT_EXPORT_TYPE_PROMO_CODES                 = "promo_codes"
 )
 
 type ReportExportPayload struct {

--- a/wallet/service/v1/promocode.pb.go
+++ b/wallet/service/v1/promocode.pb.go
@@ -2500,6 +2500,154 @@ func (x *ListUniversalCodeUsagesResponse) GetUsages() []*ListUniversalCodeUsages
 	return nil
 }
 
+// Export Promo Code Campaign
+type ExportPromoCodeCampaignRequest struct {
+	state                    protoimpl.MessageState  `protogen:"open.v1"`
+	InitiatorOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=initiator_operator_context,json=initiatorOperatorContext,proto3" json:"initiator_operator_context,omitempty"`
+	CampaignId               int64                   `protobuf:"varint,2,opt,name=campaign_id,json=campaignId,proto3" json:"campaign_id,omitempty"`
+	// "csv", "excel", or "pdf"
+	Format string `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
+	// e.g. "UTC+0", "UTC+8"
+	TimeZone        string `protobuf:"bytes,4,opt,name=time_zone,json=timeZone,proto3" json:"time_zone,omitempty"`
+	InitiatorUserId int64  `protobuf:"varint,5,opt,name=initiator_user_id,json=initiatorUserId,proto3" json:"initiator_user_id,omitempty"`
+	// Filters (same as ListPromoCodeCampaignDetails)
+	UserId        *int64  `protobuf:"varint,6,opt,name=user_id,json=userId,proto3,oneof" json:"user_id,omitempty"`
+	Status        *string `protobuf:"bytes,7,opt,name=status,proto3,oneof" json:"status,omitempty"` // "used" or "unused" (one_time only)
+	Code          *string `protobuf:"bytes,8,opt,name=code,proto3,oneof" json:"code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExportPromoCodeCampaignRequest) Reset() {
+	*x = ExportPromoCodeCampaignRequest{}
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExportPromoCodeCampaignRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExportPromoCodeCampaignRequest) ProtoMessage() {}
+
+func (x *ExportPromoCodeCampaignRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExportPromoCodeCampaignRequest.ProtoReflect.Descriptor instead.
+func (*ExportPromoCodeCampaignRequest) Descriptor() ([]byte, []int) {
+	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetInitiatorOperatorContext() *common.OperatorContext {
+	if x != nil {
+		return x.InitiatorOperatorContext
+	}
+	return nil
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetCampaignId() int64 {
+	if x != nil {
+		return x.CampaignId
+	}
+	return 0
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetFormat() string {
+	if x != nil {
+		return x.Format
+	}
+	return ""
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetTimeZone() string {
+	if x != nil {
+		return x.TimeZone
+	}
+	return ""
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetInitiatorUserId() int64 {
+	if x != nil {
+		return x.InitiatorUserId
+	}
+	return 0
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetUserId() int64 {
+	if x != nil && x.UserId != nil {
+		return *x.UserId
+	}
+	return 0
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetStatus() string {
+	if x != nil && x.Status != nil {
+		return *x.Status
+	}
+	return ""
+}
+
+func (x *ExportPromoCodeCampaignRequest) GetCode() string {
+	if x != nil && x.Code != nil {
+		return *x.Code
+	}
+	return ""
+}
+
+type ExportPromoCodeCampaignResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TaskId        int64                  `protobuf:"varint,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExportPromoCodeCampaignResponse) Reset() {
+	*x = ExportPromoCodeCampaignResponse{}
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExportPromoCodeCampaignResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExportPromoCodeCampaignResponse) ProtoMessage() {}
+
+func (x *ExportPromoCodeCampaignResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExportPromoCodeCampaignResponse.ProtoReflect.Descriptor instead.
+func (*ExportPromoCodeCampaignResponse) Descriptor() ([]byte, []int) {
+	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *ExportPromoCodeCampaignResponse) GetTaskId() int64 {
+	if x != nil {
+		return x.TaskId
+	}
+	return 0
+}
+
 // GetPromoCodeInfo - Query promo code information
 type GetPromoCodeInfoRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2510,7 +2658,7 @@ type GetPromoCodeInfoRequest struct {
 
 func (x *GetPromoCodeInfoRequest) Reset() {
 	*x = GetPromoCodeInfoRequest{}
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[32]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2522,7 +2670,7 @@ func (x *GetPromoCodeInfoRequest) String() string {
 func (*GetPromoCodeInfoRequest) ProtoMessage() {}
 
 func (x *GetPromoCodeInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[32]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2535,7 +2683,7 @@ func (x *GetPromoCodeInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPromoCodeInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetPromoCodeInfoRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{32}
+	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetPromoCodeInfoRequest) GetCode() string {
@@ -2576,7 +2724,7 @@ type GetPromoCodeInfoResponse struct {
 
 func (x *GetPromoCodeInfoResponse) Reset() {
 	*x = GetPromoCodeInfoResponse{}
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[33]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2588,7 +2736,7 @@ func (x *GetPromoCodeInfoResponse) String() string {
 func (*GetPromoCodeInfoResponse) ProtoMessage() {}
 
 func (x *GetPromoCodeInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[33]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2601,7 +2749,7 @@ func (x *GetPromoCodeInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPromoCodeInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetPromoCodeInfoResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{33}
+	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetPromoCodeInfoResponse) GetCode() string {
@@ -2719,7 +2867,7 @@ type ClaimPromoCodeRequest struct {
 
 func (x *ClaimPromoCodeRequest) Reset() {
 	*x = ClaimPromoCodeRequest{}
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[34]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2731,7 +2879,7 @@ func (x *ClaimPromoCodeRequest) String() string {
 func (*ClaimPromoCodeRequest) ProtoMessage() {}
 
 func (x *ClaimPromoCodeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[34]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2744,7 +2892,7 @@ func (x *ClaimPromoCodeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClaimPromoCodeRequest.ProtoReflect.Descriptor instead.
 func (*ClaimPromoCodeRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{34}
+	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ClaimPromoCodeRequest) GetCode() string {
@@ -2762,7 +2910,7 @@ type ClaimPromoCodeResponse struct {
 
 func (x *ClaimPromoCodeResponse) Reset() {
 	*x = ClaimPromoCodeResponse{}
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[35]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2774,7 +2922,7 @@ func (x *ClaimPromoCodeResponse) String() string {
 func (*ClaimPromoCodeResponse) ProtoMessage() {}
 
 func (x *ClaimPromoCodeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[35]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2787,7 +2935,7 @@ func (x *ClaimPromoCodeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClaimPromoCodeResponse.ProtoReflect.Descriptor instead.
 func (*ClaimPromoCodeResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{35}
+	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{37}
 }
 
 // Condition validation result
@@ -2802,7 +2950,7 @@ type ConditionValidationResult struct {
 
 func (x *ConditionValidationResult) Reset() {
 	*x = ConditionValidationResult{}
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[36]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2814,7 +2962,7 @@ func (x *ConditionValidationResult) String() string {
 func (*ConditionValidationResult) ProtoMessage() {}
 
 func (x *ConditionValidationResult) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[36]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2827,7 +2975,7 @@ func (x *ConditionValidationResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConditionValidationResult.ProtoReflect.Descriptor instead.
 func (*ConditionValidationResult) Descriptor() ([]byte, []int) {
-	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{36}
+	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ConditionValidationResult) GetConditionType() string {
@@ -2855,7 +3003,7 @@ type FreeSpinConfig_FreeSpinReward struct {
 
 func (x *FreeSpinConfig_FreeSpinReward) Reset() {
 	*x = FreeSpinConfig_FreeSpinReward{}
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[37]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2867,7 +3015,7 @@ func (x *FreeSpinConfig_FreeSpinReward) String() string {
 func (*FreeSpinConfig_FreeSpinReward) ProtoMessage() {}
 
 func (x *FreeSpinConfig_FreeSpinReward) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[37]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2919,7 +3067,7 @@ type FreeBetConfig_FreeBetReward struct {
 
 func (x *FreeBetConfig_FreeBetReward) Reset() {
 	*x = FreeBetConfig_FreeBetReward{}
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[38]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2931,7 +3079,7 @@ func (x *FreeBetConfig_FreeBetReward) String() string {
 func (*FreeBetConfig_FreeBetReward) ProtoMessage() {}
 
 func (x *FreeBetConfig_FreeBetReward) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[38]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2986,7 +3134,7 @@ type ListUniversalCodeUsagesResponse_UniversalCodeUsage struct {
 
 func (x *ListUniversalCodeUsagesResponse_UniversalCodeUsage) Reset() {
 	*x = ListUniversalCodeUsagesResponse_UniversalCodeUsage{}
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[39]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2998,7 +3146,7 @@ func (x *ListUniversalCodeUsagesResponse_UniversalCodeUsage) String() string {
 func (*ListUniversalCodeUsagesResponse_UniversalCodeUsage) ProtoMessage() {}
 
 func (x *ListUniversalCodeUsagesResponse_UniversalCodeUsage) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_service_v1_promocode_proto_msgTypes[39]
+	mi := &file_wallet_service_v1_promocode_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3294,7 +3442,23 @@ const file_wallet_service_v1_promocode_proto_rawDesc = "" +
 	"\n" +
 	"used_count\x18\x02 \x01(\x05R\tusedCount\x12\x1f\n" +
 	"\vtotal_count\x18\x03 \x01(\x05R\n" +
-	"totalCount\"-\n" +
+	"totalCount\"\xf1\x02\n" +
+	"\x1eExportPromoCodeCampaignRequest\x12Y\n" +
+	"\x1ainitiator_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x18initiatorOperatorContext\x12\x1f\n" +
+	"\vcampaign_id\x18\x02 \x01(\x03R\n" +
+	"campaignId\x12\x16\n" +
+	"\x06format\x18\x03 \x01(\tR\x06format\x12\x1b\n" +
+	"\ttime_zone\x18\x04 \x01(\tR\btimeZone\x12*\n" +
+	"\x11initiator_user_id\x18\x05 \x01(\x03R\x0finitiatorUserId\x12\x1c\n" +
+	"\auser_id\x18\x06 \x01(\x03H\x00R\x06userId\x88\x01\x01\x12\x1b\n" +
+	"\x06status\x18\a \x01(\tH\x01R\x06status\x88\x01\x01\x12\x17\n" +
+	"\x04code\x18\b \x01(\tH\x02R\x04code\x88\x01\x01B\n" +
+	"\n" +
+	"\b_user_idB\t\n" +
+	"\a_statusB\a\n" +
+	"\x05_code\":\n" +
+	"\x1fExportPromoCodeCampaignResponse\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\x03R\x06taskId\"-\n" +
 	"\x17GetPromoCodeInfoRequest\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\"\x81\x06\n" +
 	"\x18GetPromoCodeInfoResponse\x12\x12\n" +
@@ -3337,7 +3501,7 @@ func file_wallet_service_v1_promocode_proto_rawDescGZIP() []byte {
 	return file_wallet_service_v1_promocode_proto_rawDescData
 }
 
-var file_wallet_service_v1_promocode_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_wallet_service_v1_promocode_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_wallet_service_v1_promocode_proto_goTypes = []any{
 	(*FreeSpinConfig)(nil),                                     // 0: api.wallet.service.v1.FreeSpinConfig
 	(*FreeBetConfig)(nil),                                      // 1: api.wallet.service.v1.FreeBetConfig
@@ -3371,25 +3535,27 @@ var file_wallet_service_v1_promocode_proto_goTypes = []any{
 	(*GenerateUniversalPromoCodesResponse)(nil),                // 29: api.wallet.service.v1.GenerateUniversalPromoCodesResponse
 	(*ListUniversalCodeUsagesRequest)(nil),                     // 30: api.wallet.service.v1.ListUniversalCodeUsagesRequest
 	(*ListUniversalCodeUsagesResponse)(nil),                    // 31: api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	(*GetPromoCodeInfoRequest)(nil),                            // 32: api.wallet.service.v1.GetPromoCodeInfoRequest
-	(*GetPromoCodeInfoResponse)(nil),                           // 33: api.wallet.service.v1.GetPromoCodeInfoResponse
-	(*ClaimPromoCodeRequest)(nil),                              // 34: api.wallet.service.v1.ClaimPromoCodeRequest
-	(*ClaimPromoCodeResponse)(nil),                             // 35: api.wallet.service.v1.ClaimPromoCodeResponse
-	(*ConditionValidationResult)(nil),                          // 36: api.wallet.service.v1.ConditionValidationResult
-	(*FreeSpinConfig_FreeSpinReward)(nil),                      // 37: api.wallet.service.v1.FreeSpinConfig.FreeSpinReward
-	(*FreeBetConfig_FreeBetReward)(nil),                        // 38: api.wallet.service.v1.FreeBetConfig.FreeBetReward
-	(*ListUniversalCodeUsagesResponse_UniversalCodeUsage)(nil), // 39: api.wallet.service.v1.ListUniversalCodeUsagesResponse.UniversalCodeUsage
-	(*timestamppb.Timestamp)(nil),                              // 40: google.protobuf.Timestamp
-	(*common.OperatorContext)(nil),                             // 41: api.common.OperatorContext
+	(*ExportPromoCodeCampaignRequest)(nil),                     // 32: api.wallet.service.v1.ExportPromoCodeCampaignRequest
+	(*ExportPromoCodeCampaignResponse)(nil),                    // 33: api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	(*GetPromoCodeInfoRequest)(nil),                            // 34: api.wallet.service.v1.GetPromoCodeInfoRequest
+	(*GetPromoCodeInfoResponse)(nil),                           // 35: api.wallet.service.v1.GetPromoCodeInfoResponse
+	(*ClaimPromoCodeRequest)(nil),                              // 36: api.wallet.service.v1.ClaimPromoCodeRequest
+	(*ClaimPromoCodeResponse)(nil),                             // 37: api.wallet.service.v1.ClaimPromoCodeResponse
+	(*ConditionValidationResult)(nil),                          // 38: api.wallet.service.v1.ConditionValidationResult
+	(*FreeSpinConfig_FreeSpinReward)(nil),                      // 39: api.wallet.service.v1.FreeSpinConfig.FreeSpinReward
+	(*FreeBetConfig_FreeBetReward)(nil),                        // 40: api.wallet.service.v1.FreeBetConfig.FreeBetReward
+	(*ListUniversalCodeUsagesResponse_UniversalCodeUsage)(nil), // 41: api.wallet.service.v1.ListUniversalCodeUsagesResponse.UniversalCodeUsage
+	(*timestamppb.Timestamp)(nil),                              // 42: google.protobuf.Timestamp
+	(*common.OperatorContext)(nil),                             // 43: api.common.OperatorContext
 }
 var file_wallet_service_v1_promocode_proto_depIdxs = []int32{
-	37, // 0: api.wallet.service.v1.FreeSpinConfig.rewards:type_name -> api.wallet.service.v1.FreeSpinConfig.FreeSpinReward
-	38, // 1: api.wallet.service.v1.FreeBetConfig.rewards:type_name -> api.wallet.service.v1.FreeBetConfig.FreeBetReward
+	39, // 0: api.wallet.service.v1.FreeSpinConfig.rewards:type_name -> api.wallet.service.v1.FreeSpinConfig.FreeSpinReward
+	40, // 1: api.wallet.service.v1.FreeBetConfig.rewards:type_name -> api.wallet.service.v1.FreeBetConfig.FreeBetReward
 	2,  // 2: api.wallet.service.v1.PromoCodeRewardConfigs.bonus_money_config:type_name -> api.wallet.service.v1.PromoCodeBonusMoneyConfig
 	0,  // 3: api.wallet.service.v1.PromoCodeRewardConfigs.free_spin_config:type_name -> api.wallet.service.v1.FreeSpinConfig
 	1,  // 4: api.wallet.service.v1.PromoCodeRewardConfigs.free_bet_config:type_name -> api.wallet.service.v1.FreeBetConfig
-	40, // 5: api.wallet.service.v1.RegistrationTimeCondition.start_time:type_name -> google.protobuf.Timestamp
-	40, // 6: api.wallet.service.v1.RegistrationTimeCondition.end_time:type_name -> google.protobuf.Timestamp
+	42, // 5: api.wallet.service.v1.RegistrationTimeCondition.start_time:type_name -> google.protobuf.Timestamp
+	42, // 6: api.wallet.service.v1.RegistrationTimeCondition.end_time:type_name -> google.protobuf.Timestamp
 	4,  // 7: api.wallet.service.v1.PromoCodeConditions.deposit_condition:type_name -> api.wallet.service.v1.DepositCondition
 	5,  // 8: api.wallet.service.v1.PromoCodeConditions.registration_time_condition:type_name -> api.wallet.service.v1.RegistrationTimeCondition
 	6,  // 9: api.wallet.service.v1.PromoCodeConditions.invitation_condition:type_name -> api.wallet.service.v1.InvitationCondition
@@ -3397,61 +3563,62 @@ var file_wallet_service_v1_promocode_proto_depIdxs = []int32{
 	8,  // 11: api.wallet.service.v1.PromoCodeConditions.referrer_condition:type_name -> api.wallet.service.v1.ReferrerCondition
 	9,  // 12: api.wallet.service.v1.PromoCodeConditions.affiliate_condition:type_name -> api.wallet.service.v1.AffiliateCondition
 	10, // 13: api.wallet.service.v1.PromoCodeConditions.verification_status_condition:type_name -> api.wallet.service.v1.VerificationStatusCondition
-	41, // 14: api.wallet.service.v1.PromoCodeCampaign.operator_context:type_name -> api.common.OperatorContext
-	40, // 15: api.wallet.service.v1.PromoCodeCampaign.start_time:type_name -> google.protobuf.Timestamp
-	40, // 16: api.wallet.service.v1.PromoCodeCampaign.end_time:type_name -> google.protobuf.Timestamp
+	43, // 14: api.wallet.service.v1.PromoCodeCampaign.operator_context:type_name -> api.common.OperatorContext
+	42, // 15: api.wallet.service.v1.PromoCodeCampaign.start_time:type_name -> google.protobuf.Timestamp
+	42, // 16: api.wallet.service.v1.PromoCodeCampaign.end_time:type_name -> google.protobuf.Timestamp
 	11, // 17: api.wallet.service.v1.PromoCodeCampaign.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
 	3,  // 18: api.wallet.service.v1.PromoCodeCampaign.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
-	40, // 19: api.wallet.service.v1.PromoCodeCampaign.created_at:type_name -> google.protobuf.Timestamp
-	40, // 20: api.wallet.service.v1.PromoCodeCampaign.updated_at:type_name -> google.protobuf.Timestamp
-	41, // 21: api.wallet.service.v1.CreatePromoCodeCampaignRequest.initiator_operator_context:type_name -> api.common.OperatorContext
-	41, // 22: api.wallet.service.v1.CreatePromoCodeCampaignRequest.target_operator_context:type_name -> api.common.OperatorContext
-	40, // 23: api.wallet.service.v1.CreatePromoCodeCampaignRequest.start_time:type_name -> google.protobuf.Timestamp
-	40, // 24: api.wallet.service.v1.CreatePromoCodeCampaignRequest.end_time:type_name -> google.protobuf.Timestamp
+	42, // 19: api.wallet.service.v1.PromoCodeCampaign.created_at:type_name -> google.protobuf.Timestamp
+	42, // 20: api.wallet.service.v1.PromoCodeCampaign.updated_at:type_name -> google.protobuf.Timestamp
+	43, // 21: api.wallet.service.v1.CreatePromoCodeCampaignRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	43, // 22: api.wallet.service.v1.CreatePromoCodeCampaignRequest.target_operator_context:type_name -> api.common.OperatorContext
+	42, // 23: api.wallet.service.v1.CreatePromoCodeCampaignRequest.start_time:type_name -> google.protobuf.Timestamp
+	42, // 24: api.wallet.service.v1.CreatePromoCodeCampaignRequest.end_time:type_name -> google.protobuf.Timestamp
 	11, // 25: api.wallet.service.v1.CreatePromoCodeCampaignRequest.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
 	3,  // 26: api.wallet.service.v1.CreatePromoCodeCampaignRequest.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
-	41, // 27: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.initiator_operator_context:type_name -> api.common.OperatorContext
-	41, // 28: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.target_operator_context:type_name -> api.common.OperatorContext
-	40, // 29: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.start_time:type_name -> google.protobuf.Timestamp
-	40, // 30: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.end_time:type_name -> google.protobuf.Timestamp
+	43, // 27: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	43, // 28: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.target_operator_context:type_name -> api.common.OperatorContext
+	42, // 29: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.start_time:type_name -> google.protobuf.Timestamp
+	42, // 30: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.end_time:type_name -> google.protobuf.Timestamp
 	11, // 31: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
 	3,  // 32: api.wallet.service.v1.UpdatePromoCodeCampaignRequest.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
-	41, // 33: api.wallet.service.v1.UpdatePromoCodeCampaignStatusRequest.initiator_operator_context:type_name -> api.common.OperatorContext
-	41, // 34: api.wallet.service.v1.UpdatePromoCodeCampaignStatusRequest.target_operator_context:type_name -> api.common.OperatorContext
-	41, // 35: api.wallet.service.v1.ListPromoCodeCampaignsRequest.initiator_operator_context:type_name -> api.common.OperatorContext
-	41, // 36: api.wallet.service.v1.ListPromoCodeCampaignsRequest.target_operator_context:type_name -> api.common.OperatorContext
-	40, // 37: api.wallet.service.v1.ListPromoCodeCampaignsRequest.start_time:type_name -> google.protobuf.Timestamp
-	40, // 38: api.wallet.service.v1.ListPromoCodeCampaignsRequest.end_time:type_name -> google.protobuf.Timestamp
+	43, // 33: api.wallet.service.v1.UpdatePromoCodeCampaignStatusRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	43, // 34: api.wallet.service.v1.UpdatePromoCodeCampaignStatusRequest.target_operator_context:type_name -> api.common.OperatorContext
+	43, // 35: api.wallet.service.v1.ListPromoCodeCampaignsRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	43, // 36: api.wallet.service.v1.ListPromoCodeCampaignsRequest.target_operator_context:type_name -> api.common.OperatorContext
+	42, // 37: api.wallet.service.v1.ListPromoCodeCampaignsRequest.start_time:type_name -> google.protobuf.Timestamp
+	42, // 38: api.wallet.service.v1.ListPromoCodeCampaignsRequest.end_time:type_name -> google.protobuf.Timestamp
 	3,  // 39: api.wallet.service.v1.PromoCodeCampaignListItem.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
-	40, // 40: api.wallet.service.v1.PromoCodeCampaignListItem.created_at:type_name -> google.protobuf.Timestamp
-	40, // 41: api.wallet.service.v1.PromoCodeCampaignListItem.start_time:type_name -> google.protobuf.Timestamp
-	40, // 42: api.wallet.service.v1.PromoCodeCampaignListItem.end_time:type_name -> google.protobuf.Timestamp
-	40, // 43: api.wallet.service.v1.PromoCodeCampaignListItem.updated_at:type_name -> google.protobuf.Timestamp
+	42, // 40: api.wallet.service.v1.PromoCodeCampaignListItem.created_at:type_name -> google.protobuf.Timestamp
+	42, // 41: api.wallet.service.v1.PromoCodeCampaignListItem.start_time:type_name -> google.protobuf.Timestamp
+	42, // 42: api.wallet.service.v1.PromoCodeCampaignListItem.end_time:type_name -> google.protobuf.Timestamp
+	42, // 43: api.wallet.service.v1.PromoCodeCampaignListItem.updated_at:type_name -> google.protobuf.Timestamp
 	11, // 44: api.wallet.service.v1.PromoCodeCampaignListItem.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
 	20, // 45: api.wallet.service.v1.ListPromoCodeCampaignsResponse.campaigns:type_name -> api.wallet.service.v1.PromoCodeCampaignListItem
-	41, // 46: api.wallet.service.v1.ListPromoCodeCampaignDetailsRequest.initiator_operator_context:type_name -> api.common.OperatorContext
-	40, // 47: api.wallet.service.v1.PromoCodeListItem.created_at:type_name -> google.protobuf.Timestamp
-	40, // 48: api.wallet.service.v1.PromoCodeListItem.used_at:type_name -> google.protobuf.Timestamp
-	40, // 49: api.wallet.service.v1.PromoCodeListItem.expired_at:type_name -> google.protobuf.Timestamp
-	40, // 50: api.wallet.service.v1.PromoCodeUsageListItem.created_at:type_name -> google.protobuf.Timestamp
-	40, // 51: api.wallet.service.v1.PromoCodeUsageListItem.used_at:type_name -> google.protobuf.Timestamp
-	40, // 52: api.wallet.service.v1.PromoCodeUsageListItem.expired_at:type_name -> google.protobuf.Timestamp
+	43, // 46: api.wallet.service.v1.ListPromoCodeCampaignDetailsRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	42, // 47: api.wallet.service.v1.PromoCodeListItem.created_at:type_name -> google.protobuf.Timestamp
+	42, // 48: api.wallet.service.v1.PromoCodeListItem.used_at:type_name -> google.protobuf.Timestamp
+	42, // 49: api.wallet.service.v1.PromoCodeListItem.expired_at:type_name -> google.protobuf.Timestamp
+	42, // 50: api.wallet.service.v1.PromoCodeUsageListItem.created_at:type_name -> google.protobuf.Timestamp
+	42, // 51: api.wallet.service.v1.PromoCodeUsageListItem.used_at:type_name -> google.protobuf.Timestamp
+	42, // 52: api.wallet.service.v1.PromoCodeUsageListItem.expired_at:type_name -> google.protobuf.Timestamp
 	23, // 53: api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse.codes:type_name -> api.wallet.service.v1.PromoCodeListItem
 	24, // 54: api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse.usages:type_name -> api.wallet.service.v1.PromoCodeUsageListItem
-	41, // 55: api.wallet.service.v1.GenerateOneTimePromoCodesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
-	41, // 56: api.wallet.service.v1.GenerateUniversalPromoCodesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
-	41, // 57: api.wallet.service.v1.ListUniversalCodeUsagesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
-	39, // 58: api.wallet.service.v1.ListUniversalCodeUsagesResponse.usages:type_name -> api.wallet.service.v1.ListUniversalCodeUsagesResponse.UniversalCodeUsage
-	40, // 59: api.wallet.service.v1.GetPromoCodeInfoResponse.start_time:type_name -> google.protobuf.Timestamp
-	40, // 60: api.wallet.service.v1.GetPromoCodeInfoResponse.end_time:type_name -> google.protobuf.Timestamp
-	3,  // 61: api.wallet.service.v1.GetPromoCodeInfoResponse.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
-	11, // 62: api.wallet.service.v1.GetPromoCodeInfoResponse.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
-	36, // 63: api.wallet.service.v1.GetPromoCodeInfoResponse.condition_results:type_name -> api.wallet.service.v1.ConditionValidationResult
-	64, // [64:64] is the sub-list for method output_type
-	64, // [64:64] is the sub-list for method input_type
-	64, // [64:64] is the sub-list for extension type_name
-	64, // [64:64] is the sub-list for extension extendee
-	0,  // [0:64] is the sub-list for field type_name
+	43, // 55: api.wallet.service.v1.GenerateOneTimePromoCodesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	43, // 56: api.wallet.service.v1.GenerateUniversalPromoCodesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	43, // 57: api.wallet.service.v1.ListUniversalCodeUsagesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	41, // 58: api.wallet.service.v1.ListUniversalCodeUsagesResponse.usages:type_name -> api.wallet.service.v1.ListUniversalCodeUsagesResponse.UniversalCodeUsage
+	43, // 59: api.wallet.service.v1.ExportPromoCodeCampaignRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	42, // 60: api.wallet.service.v1.GetPromoCodeInfoResponse.start_time:type_name -> google.protobuf.Timestamp
+	42, // 61: api.wallet.service.v1.GetPromoCodeInfoResponse.end_time:type_name -> google.protobuf.Timestamp
+	3,  // 62: api.wallet.service.v1.GetPromoCodeInfoResponse.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs
+	11, // 63: api.wallet.service.v1.GetPromoCodeInfoResponse.reward_conditions:type_name -> api.wallet.service.v1.PromoCodeConditions
+	38, // 64: api.wallet.service.v1.GetPromoCodeInfoResponse.condition_results:type_name -> api.wallet.service.v1.ConditionValidationResult
+	65, // [65:65] is the sub-list for method output_type
+	65, // [65:65] is the sub-list for method input_type
+	65, // [65:65] is the sub-list for extension type_name
+	65, // [65:65] is the sub-list for extension extendee
+	0,  // [0:65] is the sub-list for field type_name
 }
 
 func init() { file_wallet_service_v1_promocode_proto_init() }
@@ -3462,14 +3629,15 @@ func file_wallet_service_v1_promocode_proto_init() {
 	file_wallet_service_v1_promocode_proto_msgTypes[3].OneofWrappers = []any{}
 	file_wallet_service_v1_promocode_proto_msgTypes[19].OneofWrappers = []any{}
 	file_wallet_service_v1_promocode_proto_msgTypes[22].OneofWrappers = []any{}
-	file_wallet_service_v1_promocode_proto_msgTypes[38].OneofWrappers = []any{}
+	file_wallet_service_v1_promocode_proto_msgTypes[32].OneofWrappers = []any{}
+	file_wallet_service_v1_promocode_proto_msgTypes[40].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wallet_service_v1_promocode_proto_rawDesc), len(file_wallet_service_v1_promocode_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   40,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/wallet/service/v1/promocode.pb.go
+++ b/wallet/service/v1/promocode.pb.go
@@ -2500,8 +2500,8 @@ func (x *ListUniversalCodeUsagesResponse) GetUsages() []*ListUniversalCodeUsages
 	return nil
 }
 
-// Export Promo Code Campaign
-type ExportPromoCodeCampaignRequest struct {
+// Export Promo Codes
+type ExportPromoCodesRequest struct {
 	state                    protoimpl.MessageState  `protogen:"open.v1"`
 	InitiatorOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=initiator_operator_context,json=initiatorOperatorContext,proto3" json:"initiator_operator_context,omitempty"`
 	CampaignId               int64                   `protobuf:"varint,2,opt,name=campaign_id,json=campaignId,proto3" json:"campaign_id,omitempty"`
@@ -2518,20 +2518,20 @@ type ExportPromoCodeCampaignRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ExportPromoCodeCampaignRequest) Reset() {
-	*x = ExportPromoCodeCampaignRequest{}
+func (x *ExportPromoCodesRequest) Reset() {
+	*x = ExportPromoCodesRequest{}
 	mi := &file_wallet_service_v1_promocode_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ExportPromoCodeCampaignRequest) String() string {
+func (x *ExportPromoCodesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ExportPromoCodeCampaignRequest) ProtoMessage() {}
+func (*ExportPromoCodesRequest) ProtoMessage() {}
 
-func (x *ExportPromoCodeCampaignRequest) ProtoReflect() protoreflect.Message {
+func (x *ExportPromoCodesRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_wallet_service_v1_promocode_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2543,88 +2543,88 @@ func (x *ExportPromoCodeCampaignRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ExportPromoCodeCampaignRequest.ProtoReflect.Descriptor instead.
-func (*ExportPromoCodeCampaignRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use ExportPromoCodesRequest.ProtoReflect.Descriptor instead.
+func (*ExportPromoCodesRequest) Descriptor() ([]byte, []int) {
 	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{32}
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetInitiatorOperatorContext() *common.OperatorContext {
+func (x *ExportPromoCodesRequest) GetInitiatorOperatorContext() *common.OperatorContext {
 	if x != nil {
 		return x.InitiatorOperatorContext
 	}
 	return nil
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetCampaignId() int64 {
+func (x *ExportPromoCodesRequest) GetCampaignId() int64 {
 	if x != nil {
 		return x.CampaignId
 	}
 	return 0
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetFormat() string {
+func (x *ExportPromoCodesRequest) GetFormat() string {
 	if x != nil {
 		return x.Format
 	}
 	return ""
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetTimeZone() string {
+func (x *ExportPromoCodesRequest) GetTimeZone() string {
 	if x != nil {
 		return x.TimeZone
 	}
 	return ""
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetInitiatorUserId() int64 {
+func (x *ExportPromoCodesRequest) GetInitiatorUserId() int64 {
 	if x != nil {
 		return x.InitiatorUserId
 	}
 	return 0
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetUserId() int64 {
+func (x *ExportPromoCodesRequest) GetUserId() int64 {
 	if x != nil && x.UserId != nil {
 		return *x.UserId
 	}
 	return 0
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetStatus() string {
+func (x *ExportPromoCodesRequest) GetStatus() string {
 	if x != nil && x.Status != nil {
 		return *x.Status
 	}
 	return ""
 }
 
-func (x *ExportPromoCodeCampaignRequest) GetCode() string {
+func (x *ExportPromoCodesRequest) GetCode() string {
 	if x != nil && x.Code != nil {
 		return *x.Code
 	}
 	return ""
 }
 
-type ExportPromoCodeCampaignResponse struct {
+type ExportPromoCodesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TaskId        int64                  `protobuf:"varint,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ExportPromoCodeCampaignResponse) Reset() {
-	*x = ExportPromoCodeCampaignResponse{}
+func (x *ExportPromoCodesResponse) Reset() {
+	*x = ExportPromoCodesResponse{}
 	mi := &file_wallet_service_v1_promocode_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ExportPromoCodeCampaignResponse) String() string {
+func (x *ExportPromoCodesResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ExportPromoCodeCampaignResponse) ProtoMessage() {}
+func (*ExportPromoCodesResponse) ProtoMessage() {}
 
-func (x *ExportPromoCodeCampaignResponse) ProtoReflect() protoreflect.Message {
+func (x *ExportPromoCodesResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_wallet_service_v1_promocode_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2636,12 +2636,12 @@ func (x *ExportPromoCodeCampaignResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ExportPromoCodeCampaignResponse.ProtoReflect.Descriptor instead.
-func (*ExportPromoCodeCampaignResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use ExportPromoCodesResponse.ProtoReflect.Descriptor instead.
+func (*ExportPromoCodesResponse) Descriptor() ([]byte, []int) {
 	return file_wallet_service_v1_promocode_proto_rawDescGZIP(), []int{33}
 }
 
-func (x *ExportPromoCodeCampaignResponse) GetTaskId() int64 {
+func (x *ExportPromoCodesResponse) GetTaskId() int64 {
 	if x != nil {
 		return x.TaskId
 	}
@@ -3442,8 +3442,8 @@ const file_wallet_service_v1_promocode_proto_rawDesc = "" +
 	"\n" +
 	"used_count\x18\x02 \x01(\x05R\tusedCount\x12\x1f\n" +
 	"\vtotal_count\x18\x03 \x01(\x05R\n" +
-	"totalCount\"\xf1\x02\n" +
-	"\x1eExportPromoCodeCampaignRequest\x12Y\n" +
+	"totalCount\"\xea\x02\n" +
+	"\x17ExportPromoCodesRequest\x12Y\n" +
 	"\x1ainitiator_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x18initiatorOperatorContext\x12\x1f\n" +
 	"\vcampaign_id\x18\x02 \x01(\x03R\n" +
 	"campaignId\x12\x16\n" +
@@ -3456,8 +3456,8 @@ const file_wallet_service_v1_promocode_proto_rawDesc = "" +
 	"\n" +
 	"\b_user_idB\t\n" +
 	"\a_statusB\a\n" +
-	"\x05_code\":\n" +
-	"\x1fExportPromoCodeCampaignResponse\x12\x17\n" +
+	"\x05_code\"3\n" +
+	"\x18ExportPromoCodesResponse\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\x03R\x06taskId\"-\n" +
 	"\x17GetPromoCodeInfoRequest\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\"\x81\x06\n" +
@@ -3535,8 +3535,8 @@ var file_wallet_service_v1_promocode_proto_goTypes = []any{
 	(*GenerateUniversalPromoCodesResponse)(nil),                // 29: api.wallet.service.v1.GenerateUniversalPromoCodesResponse
 	(*ListUniversalCodeUsagesRequest)(nil),                     // 30: api.wallet.service.v1.ListUniversalCodeUsagesRequest
 	(*ListUniversalCodeUsagesResponse)(nil),                    // 31: api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	(*ExportPromoCodeCampaignRequest)(nil),                     // 32: api.wallet.service.v1.ExportPromoCodeCampaignRequest
-	(*ExportPromoCodeCampaignResponse)(nil),                    // 33: api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	(*ExportPromoCodesRequest)(nil),                            // 32: api.wallet.service.v1.ExportPromoCodesRequest
+	(*ExportPromoCodesResponse)(nil),                           // 33: api.wallet.service.v1.ExportPromoCodesResponse
 	(*GetPromoCodeInfoRequest)(nil),                            // 34: api.wallet.service.v1.GetPromoCodeInfoRequest
 	(*GetPromoCodeInfoResponse)(nil),                           // 35: api.wallet.service.v1.GetPromoCodeInfoResponse
 	(*ClaimPromoCodeRequest)(nil),                              // 36: api.wallet.service.v1.ClaimPromoCodeRequest
@@ -3608,7 +3608,7 @@ var file_wallet_service_v1_promocode_proto_depIdxs = []int32{
 	43, // 56: api.wallet.service.v1.GenerateUniversalPromoCodesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
 	43, // 57: api.wallet.service.v1.ListUniversalCodeUsagesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
 	41, // 58: api.wallet.service.v1.ListUniversalCodeUsagesResponse.usages:type_name -> api.wallet.service.v1.ListUniversalCodeUsagesResponse.UniversalCodeUsage
-	43, // 59: api.wallet.service.v1.ExportPromoCodeCampaignRequest.initiator_operator_context:type_name -> api.common.OperatorContext
+	43, // 59: api.wallet.service.v1.ExportPromoCodesRequest.initiator_operator_context:type_name -> api.common.OperatorContext
 	42, // 60: api.wallet.service.v1.GetPromoCodeInfoResponse.start_time:type_name -> google.protobuf.Timestamp
 	42, // 61: api.wallet.service.v1.GetPromoCodeInfoResponse.end_time:type_name -> google.protobuf.Timestamp
 	3,  // 62: api.wallet.service.v1.GetPromoCodeInfoResponse.reward_configs:type_name -> api.wallet.service.v1.PromoCodeRewardConfigs

--- a/wallet/service/v1/promocode.pb.validate.go
+++ b/wallet/service/v1/promocode.pb.validate.go
@@ -5287,22 +5287,22 @@ var _ interface {
 	ErrorName() string
 } = ListUniversalCodeUsagesResponseValidationError{}
 
-// Validate checks the field values on ExportPromoCodeCampaignRequest with the
-// rules defined in the proto definition for this message. If any rules are
+// Validate checks the field values on ExportPromoCodesRequest with the rules
+// defined in the proto definition for this message. If any rules are
 // violated, the first error encountered is returned, or nil if there are no violations.
-func (m *ExportPromoCodeCampaignRequest) Validate() error {
+func (m *ExportPromoCodesRequest) Validate() error {
 	return m.validate(false)
 }
 
-// ValidateAll checks the field values on ExportPromoCodeCampaignRequest with
-// the rules defined in the proto definition for this message. If any rules
-// are violated, the result is a list of violation errors wrapped in
-// ExportPromoCodeCampaignRequestMultiError, or nil if none found.
-func (m *ExportPromoCodeCampaignRequest) ValidateAll() error {
+// ValidateAll checks the field values on ExportPromoCodesRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ExportPromoCodesRequestMultiError, or nil if none found.
+func (m *ExportPromoCodesRequest) ValidateAll() error {
 	return m.validate(true)
 }
 
-func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
+func (m *ExportPromoCodesRequest) validate(all bool) error {
 	if m == nil {
 		return nil
 	}
@@ -5313,7 +5313,7 @@ func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
 		switch v := interface{}(m.GetInitiatorOperatorContext()).(type) {
 		case interface{ ValidateAll() error }:
 			if err := v.ValidateAll(); err != nil {
-				errors = append(errors, ExportPromoCodeCampaignRequestValidationError{
+				errors = append(errors, ExportPromoCodesRequestValidationError{
 					field:  "InitiatorOperatorContext",
 					reason: "embedded message failed validation",
 					cause:  err,
@@ -5321,7 +5321,7 @@ func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
 			}
 		case interface{ Validate() error }:
 			if err := v.Validate(); err != nil {
-				errors = append(errors, ExportPromoCodeCampaignRequestValidationError{
+				errors = append(errors, ExportPromoCodesRequestValidationError{
 					field:  "InitiatorOperatorContext",
 					reason: "embedded message failed validation",
 					cause:  err,
@@ -5330,7 +5330,7 @@ func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
 		}
 	} else if v, ok := interface{}(m.GetInitiatorOperatorContext()).(interface{ Validate() error }); ok {
 		if err := v.Validate(); err != nil {
-			return ExportPromoCodeCampaignRequestValidationError{
+			return ExportPromoCodesRequestValidationError{
 				field:  "InitiatorOperatorContext",
 				reason: "embedded message failed validation",
 				cause:  err,
@@ -5359,19 +5359,19 @@ func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
 	}
 
 	if len(errors) > 0 {
-		return ExportPromoCodeCampaignRequestMultiError(errors)
+		return ExportPromoCodesRequestMultiError(errors)
 	}
 
 	return nil
 }
 
-// ExportPromoCodeCampaignRequestMultiError is an error wrapping multiple
-// validation errors returned by ExportPromoCodeCampaignRequest.ValidateAll()
-// if the designated constraints aren't met.
-type ExportPromoCodeCampaignRequestMultiError []error
+// ExportPromoCodesRequestMultiError is an error wrapping multiple validation
+// errors returned by ExportPromoCodesRequest.ValidateAll() if the designated
+// constraints aren't met.
+type ExportPromoCodesRequestMultiError []error
 
 // Error returns a concatenation of all the error messages it wraps.
-func (m ExportPromoCodeCampaignRequestMultiError) Error() string {
+func (m ExportPromoCodesRequestMultiError) Error() string {
 	msgs := make([]string, 0, len(m))
 	for _, err := range m {
 		msgs = append(msgs, err.Error())
@@ -5380,12 +5380,11 @@ func (m ExportPromoCodeCampaignRequestMultiError) Error() string {
 }
 
 // AllErrors returns a list of validation violation errors.
-func (m ExportPromoCodeCampaignRequestMultiError) AllErrors() []error { return m }
+func (m ExportPromoCodesRequestMultiError) AllErrors() []error { return m }
 
-// ExportPromoCodeCampaignRequestValidationError is the validation error
-// returned by ExportPromoCodeCampaignRequest.Validate if the designated
-// constraints aren't met.
-type ExportPromoCodeCampaignRequestValidationError struct {
+// ExportPromoCodesRequestValidationError is the validation error returned by
+// ExportPromoCodesRequest.Validate if the designated constraints aren't met.
+type ExportPromoCodesRequestValidationError struct {
 	field  string
 	reason string
 	cause  error
@@ -5393,24 +5392,24 @@ type ExportPromoCodeCampaignRequestValidationError struct {
 }
 
 // Field function returns field value.
-func (e ExportPromoCodeCampaignRequestValidationError) Field() string { return e.field }
+func (e ExportPromoCodesRequestValidationError) Field() string { return e.field }
 
 // Reason function returns reason value.
-func (e ExportPromoCodeCampaignRequestValidationError) Reason() string { return e.reason }
+func (e ExportPromoCodesRequestValidationError) Reason() string { return e.reason }
 
 // Cause function returns cause value.
-func (e ExportPromoCodeCampaignRequestValidationError) Cause() error { return e.cause }
+func (e ExportPromoCodesRequestValidationError) Cause() error { return e.cause }
 
 // Key function returns key value.
-func (e ExportPromoCodeCampaignRequestValidationError) Key() bool { return e.key }
+func (e ExportPromoCodesRequestValidationError) Key() bool { return e.key }
 
 // ErrorName returns error name.
-func (e ExportPromoCodeCampaignRequestValidationError) ErrorName() string {
-	return "ExportPromoCodeCampaignRequestValidationError"
+func (e ExportPromoCodesRequestValidationError) ErrorName() string {
+	return "ExportPromoCodesRequestValidationError"
 }
 
 // Error satisfies the builtin error interface
-func (e ExportPromoCodeCampaignRequestValidationError) Error() string {
+func (e ExportPromoCodesRequestValidationError) Error() string {
 	cause := ""
 	if e.cause != nil {
 		cause = fmt.Sprintf(" | caused by: %v", e.cause)
@@ -5422,14 +5421,14 @@ func (e ExportPromoCodeCampaignRequestValidationError) Error() string {
 	}
 
 	return fmt.Sprintf(
-		"invalid %sExportPromoCodeCampaignRequest.%s: %s%s",
+		"invalid %sExportPromoCodesRequest.%s: %s%s",
 		key,
 		e.field,
 		e.reason,
 		cause)
 }
 
-var _ error = ExportPromoCodeCampaignRequestValidationError{}
+var _ error = ExportPromoCodesRequestValidationError{}
 
 var _ interface {
 	Field() string
@@ -5437,24 +5436,24 @@ var _ interface {
 	Key() bool
 	Cause() error
 	ErrorName() string
-} = ExportPromoCodeCampaignRequestValidationError{}
+} = ExportPromoCodesRequestValidationError{}
 
-// Validate checks the field values on ExportPromoCodeCampaignResponse with the
-// rules defined in the proto definition for this message. If any rules are
+// Validate checks the field values on ExportPromoCodesResponse with the rules
+// defined in the proto definition for this message. If any rules are
 // violated, the first error encountered is returned, or nil if there are no violations.
-func (m *ExportPromoCodeCampaignResponse) Validate() error {
+func (m *ExportPromoCodesResponse) Validate() error {
 	return m.validate(false)
 }
 
-// ValidateAll checks the field values on ExportPromoCodeCampaignResponse with
-// the rules defined in the proto definition for this message. If any rules
-// are violated, the result is a list of violation errors wrapped in
-// ExportPromoCodeCampaignResponseMultiError, or nil if none found.
-func (m *ExportPromoCodeCampaignResponse) ValidateAll() error {
+// ValidateAll checks the field values on ExportPromoCodesResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ExportPromoCodesResponseMultiError, or nil if none found.
+func (m *ExportPromoCodesResponse) ValidateAll() error {
 	return m.validate(true)
 }
 
-func (m *ExportPromoCodeCampaignResponse) validate(all bool) error {
+func (m *ExportPromoCodesResponse) validate(all bool) error {
 	if m == nil {
 		return nil
 	}
@@ -5464,19 +5463,19 @@ func (m *ExportPromoCodeCampaignResponse) validate(all bool) error {
 	// no validation rules for TaskId
 
 	if len(errors) > 0 {
-		return ExportPromoCodeCampaignResponseMultiError(errors)
+		return ExportPromoCodesResponseMultiError(errors)
 	}
 
 	return nil
 }
 
-// ExportPromoCodeCampaignResponseMultiError is an error wrapping multiple
-// validation errors returned by ExportPromoCodeCampaignResponse.ValidateAll()
-// if the designated constraints aren't met.
-type ExportPromoCodeCampaignResponseMultiError []error
+// ExportPromoCodesResponseMultiError is an error wrapping multiple validation
+// errors returned by ExportPromoCodesResponse.ValidateAll() if the designated
+// constraints aren't met.
+type ExportPromoCodesResponseMultiError []error
 
 // Error returns a concatenation of all the error messages it wraps.
-func (m ExportPromoCodeCampaignResponseMultiError) Error() string {
+func (m ExportPromoCodesResponseMultiError) Error() string {
 	msgs := make([]string, 0, len(m))
 	for _, err := range m {
 		msgs = append(msgs, err.Error())
@@ -5485,12 +5484,11 @@ func (m ExportPromoCodeCampaignResponseMultiError) Error() string {
 }
 
 // AllErrors returns a list of validation violation errors.
-func (m ExportPromoCodeCampaignResponseMultiError) AllErrors() []error { return m }
+func (m ExportPromoCodesResponseMultiError) AllErrors() []error { return m }
 
-// ExportPromoCodeCampaignResponseValidationError is the validation error
-// returned by ExportPromoCodeCampaignResponse.Validate if the designated
-// constraints aren't met.
-type ExportPromoCodeCampaignResponseValidationError struct {
+// ExportPromoCodesResponseValidationError is the validation error returned by
+// ExportPromoCodesResponse.Validate if the designated constraints aren't met.
+type ExportPromoCodesResponseValidationError struct {
 	field  string
 	reason string
 	cause  error
@@ -5498,24 +5496,24 @@ type ExportPromoCodeCampaignResponseValidationError struct {
 }
 
 // Field function returns field value.
-func (e ExportPromoCodeCampaignResponseValidationError) Field() string { return e.field }
+func (e ExportPromoCodesResponseValidationError) Field() string { return e.field }
 
 // Reason function returns reason value.
-func (e ExportPromoCodeCampaignResponseValidationError) Reason() string { return e.reason }
+func (e ExportPromoCodesResponseValidationError) Reason() string { return e.reason }
 
 // Cause function returns cause value.
-func (e ExportPromoCodeCampaignResponseValidationError) Cause() error { return e.cause }
+func (e ExportPromoCodesResponseValidationError) Cause() error { return e.cause }
 
 // Key function returns key value.
-func (e ExportPromoCodeCampaignResponseValidationError) Key() bool { return e.key }
+func (e ExportPromoCodesResponseValidationError) Key() bool { return e.key }
 
 // ErrorName returns error name.
-func (e ExportPromoCodeCampaignResponseValidationError) ErrorName() string {
-	return "ExportPromoCodeCampaignResponseValidationError"
+func (e ExportPromoCodesResponseValidationError) ErrorName() string {
+	return "ExportPromoCodesResponseValidationError"
 }
 
 // Error satisfies the builtin error interface
-func (e ExportPromoCodeCampaignResponseValidationError) Error() string {
+func (e ExportPromoCodesResponseValidationError) Error() string {
 	cause := ""
 	if e.cause != nil {
 		cause = fmt.Sprintf(" | caused by: %v", e.cause)
@@ -5527,14 +5525,14 @@ func (e ExportPromoCodeCampaignResponseValidationError) Error() string {
 	}
 
 	return fmt.Sprintf(
-		"invalid %sExportPromoCodeCampaignResponse.%s: %s%s",
+		"invalid %sExportPromoCodesResponse.%s: %s%s",
 		key,
 		e.field,
 		e.reason,
 		cause)
 }
 
-var _ error = ExportPromoCodeCampaignResponseValidationError{}
+var _ error = ExportPromoCodesResponseValidationError{}
 
 var _ interface {
 	Field() string
@@ -5542,7 +5540,7 @@ var _ interface {
 	Key() bool
 	Cause() error
 	ErrorName() string
-} = ExportPromoCodeCampaignResponseValidationError{}
+} = ExportPromoCodesResponseValidationError{}
 
 // Validate checks the field values on GetPromoCodeInfoRequest with the rules
 // defined in the proto definition for this message. If any rules are

--- a/wallet/service/v1/promocode.pb.validate.go
+++ b/wallet/service/v1/promocode.pb.validate.go
@@ -5287,6 +5287,263 @@ var _ interface {
 	ErrorName() string
 } = ListUniversalCodeUsagesResponseValidationError{}
 
+// Validate checks the field values on ExportPromoCodeCampaignRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ExportPromoCodeCampaignRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ExportPromoCodeCampaignRequest with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// ExportPromoCodeCampaignRequestMultiError, or nil if none found.
+func (m *ExportPromoCodeCampaignRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ExportPromoCodeCampaignRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetInitiatorOperatorContext()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ExportPromoCodeCampaignRequestValidationError{
+					field:  "InitiatorOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ExportPromoCodeCampaignRequestValidationError{
+					field:  "InitiatorOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetInitiatorOperatorContext()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ExportPromoCodeCampaignRequestValidationError{
+				field:  "InitiatorOperatorContext",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for CampaignId
+
+	// no validation rules for Format
+
+	// no validation rules for TimeZone
+
+	// no validation rules for InitiatorUserId
+
+	if m.UserId != nil {
+		// no validation rules for UserId
+	}
+
+	if m.Status != nil {
+		// no validation rules for Status
+	}
+
+	if m.Code != nil {
+		// no validation rules for Code
+	}
+
+	if len(errors) > 0 {
+		return ExportPromoCodeCampaignRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// ExportPromoCodeCampaignRequestMultiError is an error wrapping multiple
+// validation errors returned by ExportPromoCodeCampaignRequest.ValidateAll()
+// if the designated constraints aren't met.
+type ExportPromoCodeCampaignRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ExportPromoCodeCampaignRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ExportPromoCodeCampaignRequestMultiError) AllErrors() []error { return m }
+
+// ExportPromoCodeCampaignRequestValidationError is the validation error
+// returned by ExportPromoCodeCampaignRequest.Validate if the designated
+// constraints aren't met.
+type ExportPromoCodeCampaignRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ExportPromoCodeCampaignRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ExportPromoCodeCampaignRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ExportPromoCodeCampaignRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ExportPromoCodeCampaignRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ExportPromoCodeCampaignRequestValidationError) ErrorName() string {
+	return "ExportPromoCodeCampaignRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ExportPromoCodeCampaignRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sExportPromoCodeCampaignRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ExportPromoCodeCampaignRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ExportPromoCodeCampaignRequestValidationError{}
+
+// Validate checks the field values on ExportPromoCodeCampaignResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ExportPromoCodeCampaignResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ExportPromoCodeCampaignResponse with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// ExportPromoCodeCampaignResponseMultiError, or nil if none found.
+func (m *ExportPromoCodeCampaignResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ExportPromoCodeCampaignResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for TaskId
+
+	if len(errors) > 0 {
+		return ExportPromoCodeCampaignResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// ExportPromoCodeCampaignResponseMultiError is an error wrapping multiple
+// validation errors returned by ExportPromoCodeCampaignResponse.ValidateAll()
+// if the designated constraints aren't met.
+type ExportPromoCodeCampaignResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ExportPromoCodeCampaignResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ExportPromoCodeCampaignResponseMultiError) AllErrors() []error { return m }
+
+// ExportPromoCodeCampaignResponseValidationError is the validation error
+// returned by ExportPromoCodeCampaignResponse.Validate if the designated
+// constraints aren't met.
+type ExportPromoCodeCampaignResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ExportPromoCodeCampaignResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ExportPromoCodeCampaignResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ExportPromoCodeCampaignResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ExportPromoCodeCampaignResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ExportPromoCodeCampaignResponseValidationError) ErrorName() string {
+	return "ExportPromoCodeCampaignResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ExportPromoCodeCampaignResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sExportPromoCodeCampaignResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ExportPromoCodeCampaignResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ExportPromoCodeCampaignResponseValidationError{}
+
 // Validate checks the field values on GetPromoCodeInfoRequest with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, the first error encountered is returned, or nil if there are no violations.

--- a/wallet/service/v1/promocode.proto
+++ b/wallet/service/v1/promocode.proto
@@ -355,6 +355,25 @@ message ListUniversalCodeUsagesResponse {
 	}
 }
 
+// Export Promo Code Campaign
+message ExportPromoCodeCampaignRequest {
+	api.common.OperatorContext initiator_operator_context = 1;
+	int64 campaign_id = 2;
+	// "csv", "excel", or "pdf"
+	string format = 3;
+	// e.g. "UTC+0", "UTC+8"
+	string time_zone = 4;
+	int64 initiator_user_id = 5;
+	// Filters (same as ListPromoCodeCampaignDetails)
+	optional int64 user_id = 6;
+	optional string status = 7;   // "used" or "unused" (one_time only)
+	optional string code = 8;
+}
+
+message ExportPromoCodeCampaignResponse {
+	int64 task_id = 1;
+}
+
 // ============================================
 // User Promo Code APIs
 // ============================================

--- a/wallet/service/v1/promocode.proto
+++ b/wallet/service/v1/promocode.proto
@@ -355,8 +355,8 @@ message ListUniversalCodeUsagesResponse {
 	}
 }
 
-// Export Promo Code Campaign
-message ExportPromoCodeCampaignRequest {
+// Export Promo Codes
+message ExportPromoCodesRequest {
 	api.common.OperatorContext initiator_operator_context = 1;
 	int64 campaign_id = 2;
 	// "csv", "excel", or "pdf"
@@ -370,7 +370,7 @@ message ExportPromoCodeCampaignRequest {
 	optional string code = 8;
 }
 
-message ExportPromoCodeCampaignResponse {
+message ExportPromoCodesResponse {
 	int64 task_id = 1;
 }
 

--- a/wallet/service/v1/wallet.pb.go
+++ b/wallet/service/v1/wallet.pb.go
@@ -20268,7 +20268,7 @@ const file_wallet_service_v1_wallet_proto_rawDesc = "" +
 	"updated_at\x18\x15 \x01(\x03R\tupdatedAt\x12!\n" +
 	"\fcompleted_at\x18\x16 \x01(\x03R\vcompletedAt\x12\x1d\n" +
 	"\n" +
-	"revoked_at\x18\x17 \x01(\x03R\trevokedAt2\x94e\n" +
+	"revoked_at\x18\x17 \x01(\x03R\trevokedAt2\xa1f\n" +
 	"\x06Wallet\x12\x95\x01\n" +
 	"\x0fGetUserBalances\x12-.api.wallet.service.v1.GetUserBalancesRequest\x1a..api.wallet.service.v1.GetUserBalancesResponse\"#\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v1/wallet/balances/list\x12o\n" +
 	"\x0eGetUserBalance\x12,.api.wallet.service.v1.GetUserBalanceRequest\x1a-.api.wallet.service.v1.GetUserBalanceResponse\"\x00\x12\xa9\x01\n" +
@@ -20327,7 +20327,8 @@ const file_wallet_service_v1_wallet_proto_rawDesc = "" +
 	"\x1cListPromoCodeCampaignDetails\x12:.api.wallet.service.v1.ListPromoCodeCampaignDetailsRequest\x1a;.api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse\"\x00\x12\x90\x01\n" +
 	"\x19GenerateOneTimePromoCodes\x127.api.wallet.service.v1.GenerateOneTimePromoCodesRequest\x1a8.api.wallet.service.v1.GenerateOneTimePromoCodesResponse\"\x00\x12\x96\x01\n" +
 	"\x1bGenerateUniversalPromoCodes\x129.api.wallet.service.v1.GenerateUniversalPromoCodesRequest\x1a:.api.wallet.service.v1.GenerateUniversalPromoCodesResponse\"\x00\x12\x8a\x01\n" +
-	"\x17ListUniversalCodeUsages\x125.api.wallet.service.v1.ListUniversalCodeUsagesRequest\x1a6.api.wallet.service.v1.ListUniversalCodeUsagesResponse\"\x00\x12\x9a\x01\n" +
+	"\x17ListUniversalCodeUsages\x125.api.wallet.service.v1.ListUniversalCodeUsagesRequest\x1a6.api.wallet.service.v1.ListUniversalCodeUsagesResponse\"\x00\x12\x8a\x01\n" +
+	"\x17ExportPromoCodeCampaign\x125.api.wallet.service.v1.ExportPromoCodeCampaignRequest\x1a6.api.wallet.service.v1.ExportPromoCodeCampaignResponse\"\x00\x12\x9a\x01\n" +
 	"\x10GetPromoCodeInfo\x12..api.wallet.service.v1.GetPromoCodeInfoRequest\x1a/.api.wallet.service.v1.GetPromoCodeInfoResponse\"%\x82\xd3\xe4\x93\x02\x1f:\x01*\"\x1a/v1/wallet/promo-code/info\x12\x95\x01\n" +
 	"\x0eClaimPromoCode\x12,.api.wallet.service.v1.ClaimPromoCodeRequest\x1a-.api.wallet.service.v1.ClaimPromoCodeResponse\"&\x82\xd3\xe4\x93\x02 :\x01*\"\x1b/v1/wallet/promo-code/claim\x12\xcb\x01\n" +
 	"\x1cGetUserDepositRewardSequence\x12:.api.wallet.service.v1.GetUserDepositRewardSequenceRequest\x1a;.api.wallet.service.v1.GetUserDepositRewardSequenceResponse\"2\x82\xd3\xe4\x93\x02,:\x01*\"'/v1/wallet/deposit-reward/user-sequence\x12\x9c\x01\n" +
@@ -20603,18 +20604,20 @@ var file_wallet_service_v1_wallet_proto_goTypes = []any{
 	(*GenerateOneTimePromoCodesRequest)(nil),      // 222: api.wallet.service.v1.GenerateOneTimePromoCodesRequest
 	(*GenerateUniversalPromoCodesRequest)(nil),    // 223: api.wallet.service.v1.GenerateUniversalPromoCodesRequest
 	(*ListUniversalCodeUsagesRequest)(nil),        // 224: api.wallet.service.v1.ListUniversalCodeUsagesRequest
-	(*GetPromoCodeInfoRequest)(nil),               // 225: api.wallet.service.v1.GetPromoCodeInfoRequest
-	(*ClaimPromoCodeRequest)(nil),                 // 226: api.wallet.service.v1.ClaimPromoCodeRequest
-	(*CreatePromoCodeCampaignResponse)(nil),       // 227: api.wallet.service.v1.CreatePromoCodeCampaignResponse
-	(*UpdatePromoCodeCampaignResponse)(nil),       // 228: api.wallet.service.v1.UpdatePromoCodeCampaignResponse
-	(*UpdatePromoCodeCampaignStatusResponse)(nil), // 229: api.wallet.service.v1.UpdatePromoCodeCampaignStatusResponse
-	(*ListPromoCodeCampaignsResponse)(nil),        // 230: api.wallet.service.v1.ListPromoCodeCampaignsResponse
-	(*ListPromoCodeCampaignDetailsResponse)(nil),  // 231: api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse
-	(*GenerateOneTimePromoCodesResponse)(nil),     // 232: api.wallet.service.v1.GenerateOneTimePromoCodesResponse
-	(*GenerateUniversalPromoCodesResponse)(nil),   // 233: api.wallet.service.v1.GenerateUniversalPromoCodesResponse
-	(*ListUniversalCodeUsagesResponse)(nil),       // 234: api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	(*GetPromoCodeInfoResponse)(nil),              // 235: api.wallet.service.v1.GetPromoCodeInfoResponse
-	(*ClaimPromoCodeResponse)(nil),                // 236: api.wallet.service.v1.ClaimPromoCodeResponse
+	(*ExportPromoCodeCampaignRequest)(nil),        // 225: api.wallet.service.v1.ExportPromoCodeCampaignRequest
+	(*GetPromoCodeInfoRequest)(nil),               // 226: api.wallet.service.v1.GetPromoCodeInfoRequest
+	(*ClaimPromoCodeRequest)(nil),                 // 227: api.wallet.service.v1.ClaimPromoCodeRequest
+	(*CreatePromoCodeCampaignResponse)(nil),       // 228: api.wallet.service.v1.CreatePromoCodeCampaignResponse
+	(*UpdatePromoCodeCampaignResponse)(nil),       // 229: api.wallet.service.v1.UpdatePromoCodeCampaignResponse
+	(*UpdatePromoCodeCampaignStatusResponse)(nil), // 230: api.wallet.service.v1.UpdatePromoCodeCampaignStatusResponse
+	(*ListPromoCodeCampaignsResponse)(nil),        // 231: api.wallet.service.v1.ListPromoCodeCampaignsResponse
+	(*ListPromoCodeCampaignDetailsResponse)(nil),  // 232: api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse
+	(*GenerateOneTimePromoCodesResponse)(nil),     // 233: api.wallet.service.v1.GenerateOneTimePromoCodesResponse
+	(*GenerateUniversalPromoCodesResponse)(nil),   // 234: api.wallet.service.v1.GenerateUniversalPromoCodesResponse
+	(*ListUniversalCodeUsagesResponse)(nil),       // 235: api.wallet.service.v1.ListUniversalCodeUsagesResponse
+	(*ExportPromoCodeCampaignResponse)(nil),       // 236: api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	(*GetPromoCodeInfoResponse)(nil),              // 237: api.wallet.service.v1.GetPromoCodeInfoResponse
+	(*ClaimPromoCodeResponse)(nil),                // 238: api.wallet.service.v1.ClaimPromoCodeResponse
 }
 var file_wallet_service_v1_wallet_proto_depIdxs = []int32{
 	188, // 0: api.wallet.service.v1.GetUserBalancesResponse.balances:type_name -> api.wallet.service.v1.GetUserBalancesResponse.Balance
@@ -20911,132 +20914,134 @@ var file_wallet_service_v1_wallet_proto_depIdxs = []int32{
 	222, // 291: api.wallet.service.v1.Wallet.GenerateOneTimePromoCodes:input_type -> api.wallet.service.v1.GenerateOneTimePromoCodesRequest
 	223, // 292: api.wallet.service.v1.Wallet.GenerateUniversalPromoCodes:input_type -> api.wallet.service.v1.GenerateUniversalPromoCodesRequest
 	224, // 293: api.wallet.service.v1.Wallet.ListUniversalCodeUsages:input_type -> api.wallet.service.v1.ListUniversalCodeUsagesRequest
-	225, // 294: api.wallet.service.v1.Wallet.GetPromoCodeInfo:input_type -> api.wallet.service.v1.GetPromoCodeInfoRequest
-	226, // 295: api.wallet.service.v1.Wallet.ClaimPromoCode:input_type -> api.wallet.service.v1.ClaimPromoCodeRequest
-	89,  // 296: api.wallet.service.v1.Wallet.GetUserDepositRewardSequence:input_type -> api.wallet.service.v1.GetUserDepositRewardSequenceRequest
-	91,  // 297: api.wallet.service.v1.Wallet.GetGamificationCurrencyConfig:input_type -> api.wallet.service.v1.GetGamificationCurrencyConfigRequest
-	97,  // 298: api.wallet.service.v1.Wallet.UpdateOperatorCurrencyConfig:input_type -> api.wallet.service.v1.UpdateOperatorCurrencyConfigRequest
-	99,  // 299: api.wallet.service.v1.Wallet.UpdateWalletConfig:input_type -> api.wallet.service.v1.UpdateWalletConfigRequest
-	101, // 300: api.wallet.service.v1.Wallet.BonusTransfer:input_type -> api.wallet.service.v1.BonusTransferRequest
-	106, // 301: api.wallet.service.v1.Wallet.AddResponsibleGamblingConfig:input_type -> api.wallet.service.v1.AddResponsibleGamblingConfigRequest
-	108, // 302: api.wallet.service.v1.Wallet.DeleteResponsibleGamblingConfig:input_type -> api.wallet.service.v1.DeleteResponsibleGamblingConfigRequest
-	112, // 303: api.wallet.service.v1.Wallet.ListResponsibleGamblingConfigs:input_type -> api.wallet.service.v1.ListResponsibleGamblingConfigsRequest
-	114, // 304: api.wallet.service.v1.Wallet.GetResponsibleGamblingConfig:input_type -> api.wallet.service.v1.GetResponsibleGamblingConfigRequest
-	116, // 305: api.wallet.service.v1.Wallet.ListCustomerRecords:input_type -> api.wallet.service.v1.ListCustomerRecordsRequest
-	118, // 306: api.wallet.service.v1.Wallet.ExportCustomerRecords:input_type -> api.wallet.service.v1.ExportCustomerRecordsRequest
-	121, // 307: api.wallet.service.v1.Wallet.SetFICAThresholdConfig:input_type -> api.wallet.service.v1.SetFICAThresholdConfigRequest
-	123, // 308: api.wallet.service.v1.Wallet.GetFICAThresholdConfig:input_type -> api.wallet.service.v1.GetFICAThresholdConfigRequest
-	125, // 309: api.wallet.service.v1.Wallet.ListFICAThresholdTransactions:input_type -> api.wallet.service.v1.ListFICAThresholdTransactionsRequest
-	127, // 310: api.wallet.service.v1.Wallet.ExportFICAThresholdTransactions:input_type -> api.wallet.service.v1.ExportFICAThresholdTransactionsRequest
-	129, // 311: api.wallet.service.v1.Wallet.ListBalancesByUserIds:input_type -> api.wallet.service.v1.ListBalancesByUserIdsRequest
-	131, // 312: api.wallet.service.v1.Wallet.ListManualJournalEntries:input_type -> api.wallet.service.v1.ListManualJournalEntriesRequest
-	133, // 313: api.wallet.service.v1.Wallet.ExportManualJournalEntries:input_type -> api.wallet.service.v1.ExportManualJournalEntriesRequest
-	135, // 314: api.wallet.service.v1.Wallet.ListTimeRangeDepositCredits:input_type -> api.wallet.service.v1.ListTimeRangeDepositCreditsRequest
-	137, // 315: api.wallet.service.v1.Wallet.ListUserOverview:input_type -> api.wallet.service.v1.ListUserOverviewRequest
-	139, // 316: api.wallet.service.v1.Wallet.GetUserGameTransactionsSummary:input_type -> api.wallet.service.v1.GetUserGameTransactionsSummaryRequest
-	141, // 317: api.wallet.service.v1.Wallet.CreditFreespinWin:input_type -> api.wallet.service.v1.CreditFreespinWinRequest
-	143, // 318: api.wallet.service.v1.Wallet.CreditFreeBetWin:input_type -> api.wallet.service.v1.CreditFreeBetWinRequest
-	145, // 319: api.wallet.service.v1.Wallet.GetOperatorUserFinancialSummary:input_type -> api.wallet.service.v1.GetOperatorUserFinancialSummaryRequest
-	93,  // 320: api.wallet.service.v1.Wallet.GetWalletConfig:input_type -> api.wallet.service.v1.GetWalletConfigRequest
-	148, // 321: api.wallet.service.v1.Wallet.BatchGetUserFinancialMetrics:input_type -> api.wallet.service.v1.BatchGetUserFinancialMetricsRequest
-	150, // 322: api.wallet.service.v1.Wallet.ManualAdjustCreditTurnoverField:input_type -> api.wallet.service.v1.ManualAdjustCreditTurnoverFieldRequest
-	152, // 323: api.wallet.service.v1.Wallet.ListUserFreeRewards:input_type -> api.wallet.service.v1.ListUserFreeRewardsRequest
-	184, // 324: api.wallet.service.v1.Wallet.ListUserFreeRewardsBO:input_type -> api.wallet.service.v1.ListUserFreeRewardsBORequest
-	177, // 325: api.wallet.service.v1.Wallet.ListOperatorWithdrawableAmounts:input_type -> api.wallet.service.v1.ListOperatorWithdrawableAmountsRequest
-	180, // 326: api.wallet.service.v1.Wallet.GetOperatorWithdrawCheckInfo:input_type -> api.wallet.service.v1.GetOperatorWithdrawCheckInfoRequest
-	182, // 327: api.wallet.service.v1.Wallet.GetOperatorWithdrawableAmount:input_type -> api.wallet.service.v1.GetOperatorWithdrawableAmountRequest
-	1,   // 328: api.wallet.service.v1.Wallet.GetUserBalances:output_type -> api.wallet.service.v1.GetUserBalancesResponse
-	3,   // 329: api.wallet.service.v1.Wallet.GetUserBalance:output_type -> api.wallet.service.v1.GetUserBalanceResponse
-	105, // 330: api.wallet.service.v1.Wallet.GetUserBalanceDetails:output_type -> api.wallet.service.v1.GetUserBalanceDetailsResponse
-	5,   // 331: api.wallet.service.v1.Wallet.Credit:output_type -> api.wallet.service.v1.CreditResponse
-	7,   // 332: api.wallet.service.v1.Wallet.Debit:output_type -> api.wallet.service.v1.DebitResponse
-	10,  // 333: api.wallet.service.v1.Wallet.GameDebit:output_type -> api.wallet.service.v1.GameDebitResponse
-	12,  // 334: api.wallet.service.v1.Wallet.GameCredit:output_type -> api.wallet.service.v1.GameCreditResponse
-	175, // 335: api.wallet.service.v1.Wallet.GameBatchBetAndSettle:output_type -> api.wallet.service.v1.GameBatchBetAndSettleResponse
-	15,  // 336: api.wallet.service.v1.Wallet.Freeze:output_type -> api.wallet.service.v1.FreezeResponse
-	17,  // 337: api.wallet.service.v1.Wallet.Settle:output_type -> api.wallet.service.v1.SettleResponse
-	19,  // 338: api.wallet.service.v1.Wallet.Rollback:output_type -> api.wallet.service.v1.RollbackResponse
-	21,  // 339: api.wallet.service.v1.Wallet.GetWallets:output_type -> api.wallet.service.v1.GetWalletsResponse
-	23,  // 340: api.wallet.service.v1.Wallet.ListWalletBalanceTransactions:output_type -> api.wallet.service.v1.ListWalletBalanceTransactionsResponse
-	25,  // 341: api.wallet.service.v1.Wallet.GetWalletBalanceTransactionsByIds:output_type -> api.wallet.service.v1.GetWalletBalanceTransactionsByIdsResponse
-	27,  // 342: api.wallet.service.v1.Wallet.GetWalletCreditTransactions:output_type -> api.wallet.service.v1.GetWalletCreditTransactionsResponse
-	29,  // 343: api.wallet.service.v1.Wallet.GetExchangeRates:output_type -> api.wallet.service.v1.GetExchangeRatesResponse
-	31,  // 344: api.wallet.service.v1.Wallet.GetExchangeRatesWithBaseCurrency:output_type -> api.wallet.service.v1.GetExchangeRatesWithBaseCurrencyResponse
-	33,  // 345: api.wallet.service.v1.Wallet.GetUserTransactionSummary:output_type -> api.wallet.service.v1.GetUserTransactionSummaryResponse
-	35,  // 346: api.wallet.service.v1.Wallet.ListUserTransactionSummaries:output_type -> api.wallet.service.v1.ListUserTransactionSummariesResponse
-	37,  // 347: api.wallet.service.v1.Wallet.GetBackofficeUserOverviewFromWallet:output_type -> api.wallet.service.v1.GetBackofficeUserOverviewFromWalletResponse
-	40,  // 348: api.wallet.service.v1.Wallet.AddCurrency:output_type -> api.wallet.service.v1.AddCurrencyResponse
-	42,  // 349: api.wallet.service.v1.Wallet.UpdateCurrency:output_type -> api.wallet.service.v1.UpdateCurrencyResponse
-	44,  // 350: api.wallet.service.v1.Wallet.GetCurrencies:output_type -> api.wallet.service.v1.GetCurrenciesResponse
-	46,  // 351: api.wallet.service.v1.Wallet.ListCurrencies:output_type -> api.wallet.service.v1.ListCurrenciesResponse
-	48,  // 352: api.wallet.service.v1.Wallet.UpdateOperatorCurrency:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyResponse
-	50,  // 353: api.wallet.service.v1.Wallet.UpdateUserCurrency:output_type -> api.wallet.service.v1.UpdateUserCurrencyResponse
-	53,  // 354: api.wallet.service.v1.Wallet.ListBottomOperatorBalances:output_type -> api.wallet.service.v1.ListBottomOperatorBalancesResponse
-	55,  // 355: api.wallet.service.v1.Wallet.ListCompanyOperatorBalances:output_type -> api.wallet.service.v1.ListCompanyOperatorBalancesResponse
-	57,  // 356: api.wallet.service.v1.Wallet.OperatorTransfer:output_type -> api.wallet.service.v1.OperatorTransferResponse
-	59,  // 357: api.wallet.service.v1.Wallet.OperatorSwap:output_type -> api.wallet.service.v1.OperatorSwapResponse
-	61,  // 358: api.wallet.service.v1.Wallet.OperatorFreeze:output_type -> api.wallet.service.v1.OperatorFreezeResponse
-	63,  // 359: api.wallet.service.v1.Wallet.OperatorRollback:output_type -> api.wallet.service.v1.OperatorRollbackResponse
-	65,  // 360: api.wallet.service.v1.Wallet.OperatorSettle:output_type -> api.wallet.service.v1.OperatorSettleResponse
-	67,  // 361: api.wallet.service.v1.Wallet.GetOperatorBalance:output_type -> api.wallet.service.v1.GetOperatorBalanceResponse
-	70,  // 362: api.wallet.service.v1.Wallet.ListOperatorBalanceTransactions:output_type -> api.wallet.service.v1.ListOperatorBalanceTransactionsResponse
-	72,  // 363: api.wallet.service.v1.Wallet.OperatorDebit:output_type -> api.wallet.service.v1.OperatorDebitResponse
-	74,  // 364: api.wallet.service.v1.Wallet.OperatorBalanceAdjust:output_type -> api.wallet.service.v1.OperatorBalanceAdjustResponse
-	76,  // 365: api.wallet.service.v1.Wallet.UpdateOperatorBalance:output_type -> api.wallet.service.v1.UpdateOperatorBalanceResponse
-	78,  // 366: api.wallet.service.v1.Wallet.GetOperatorTransactionSummary:output_type -> api.wallet.service.v1.GetOperatorTransactionSummaryResponse
-	170, // 367: api.wallet.service.v1.Wallet.GetCompanyFinancialSummary:output_type -> api.wallet.service.v1.GetCompanyFinancialSummaryResponse
-	80,  // 368: api.wallet.service.v1.Wallet.GetOperatorBalanceTransactionsByIds:output_type -> api.wallet.service.v1.GetOperatorBalanceTransactionsByIdsResponse
-	84,  // 369: api.wallet.service.v1.Wallet.SetDepositRewardSequences:output_type -> api.wallet.service.v1.SetDepositRewardSequencesResponse
-	86,  // 370: api.wallet.service.v1.Wallet.DeleteDepositRewardSequences:output_type -> api.wallet.service.v1.DeleteDepositRewardSequencesResponse
-	88,  // 371: api.wallet.service.v1.Wallet.GetDepositRewardConfig:output_type -> api.wallet.service.v1.GetDepositRewardConfigResponse
-	162, // 372: api.wallet.service.v1.Wallet.SetAppDownloadRewardConfig:output_type -> api.wallet.service.v1.SetAppDownloadRewardConfigResponse
-	164, // 373: api.wallet.service.v1.Wallet.GetAppDownloadRewardConfig:output_type -> api.wallet.service.v1.GetAppDownloadRewardConfigResponse
-	166, // 374: api.wallet.service.v1.Wallet.ClaimAppDownloadReward:output_type -> api.wallet.service.v1.ClaimAppDownloadRewardResponse
-	168, // 375: api.wallet.service.v1.Wallet.GetAppDownloadRewardStatus:output_type -> api.wallet.service.v1.GetAppDownloadRewardStatusResponse
-	227, // 376: api.wallet.service.v1.Wallet.CreatePromoCodeCampaign:output_type -> api.wallet.service.v1.CreatePromoCodeCampaignResponse
-	228, // 377: api.wallet.service.v1.Wallet.UpdatePromoCodeCampaign:output_type -> api.wallet.service.v1.UpdatePromoCodeCampaignResponse
-	229, // 378: api.wallet.service.v1.Wallet.UpdatePromoCodeCampaignStatus:output_type -> api.wallet.service.v1.UpdatePromoCodeCampaignStatusResponse
-	230, // 379: api.wallet.service.v1.Wallet.ListPromoCodeCampaigns:output_type -> api.wallet.service.v1.ListPromoCodeCampaignsResponse
-	231, // 380: api.wallet.service.v1.Wallet.ListPromoCodeCampaignDetails:output_type -> api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse
-	232, // 381: api.wallet.service.v1.Wallet.GenerateOneTimePromoCodes:output_type -> api.wallet.service.v1.GenerateOneTimePromoCodesResponse
-	233, // 382: api.wallet.service.v1.Wallet.GenerateUniversalPromoCodes:output_type -> api.wallet.service.v1.GenerateUniversalPromoCodesResponse
-	234, // 383: api.wallet.service.v1.Wallet.ListUniversalCodeUsages:output_type -> api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	235, // 384: api.wallet.service.v1.Wallet.GetPromoCodeInfo:output_type -> api.wallet.service.v1.GetPromoCodeInfoResponse
-	236, // 385: api.wallet.service.v1.Wallet.ClaimPromoCode:output_type -> api.wallet.service.v1.ClaimPromoCodeResponse
-	90,  // 386: api.wallet.service.v1.Wallet.GetUserDepositRewardSequence:output_type -> api.wallet.service.v1.GetUserDepositRewardSequenceResponse
-	96,  // 387: api.wallet.service.v1.Wallet.GetGamificationCurrencyConfig:output_type -> api.wallet.service.v1.GetGamificationCurrencyConfigResponse
-	98,  // 388: api.wallet.service.v1.Wallet.UpdateOperatorCurrencyConfig:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse
-	100, // 389: api.wallet.service.v1.Wallet.UpdateWalletConfig:output_type -> api.wallet.service.v1.UpdateWalletConfigResponse
-	102, // 390: api.wallet.service.v1.Wallet.BonusTransfer:output_type -> api.wallet.service.v1.BonusTransferResponse
-	107, // 391: api.wallet.service.v1.Wallet.AddResponsibleGamblingConfig:output_type -> api.wallet.service.v1.AddResponsibleGamblingConfigResponse
-	109, // 392: api.wallet.service.v1.Wallet.DeleteResponsibleGamblingConfig:output_type -> api.wallet.service.v1.DeleteResponsibleGamblingConfigResponse
-	113, // 393: api.wallet.service.v1.Wallet.ListResponsibleGamblingConfigs:output_type -> api.wallet.service.v1.ListResponsibleGamblingConfigsResponse
-	115, // 394: api.wallet.service.v1.Wallet.GetResponsibleGamblingConfig:output_type -> api.wallet.service.v1.GetResponsibleGamblingConfigResponse
-	117, // 395: api.wallet.service.v1.Wallet.ListCustomerRecords:output_type -> api.wallet.service.v1.ListCustomerRecordsResponse
-	119, // 396: api.wallet.service.v1.Wallet.ExportCustomerRecords:output_type -> api.wallet.service.v1.ExportCustomerRecordsResponse
-	122, // 397: api.wallet.service.v1.Wallet.SetFICAThresholdConfig:output_type -> api.wallet.service.v1.SetFICAThresholdConfigResponse
-	124, // 398: api.wallet.service.v1.Wallet.GetFICAThresholdConfig:output_type -> api.wallet.service.v1.GetFICAThresholdConfigResponse
-	126, // 399: api.wallet.service.v1.Wallet.ListFICAThresholdTransactions:output_type -> api.wallet.service.v1.ListFICAThresholdTransactionsResponse
-	128, // 400: api.wallet.service.v1.Wallet.ExportFICAThresholdTransactions:output_type -> api.wallet.service.v1.ExportFICAThresholdTransactionsResponse
-	130, // 401: api.wallet.service.v1.Wallet.ListBalancesByUserIds:output_type -> api.wallet.service.v1.ListBalancesByUserIdsResponse
-	132, // 402: api.wallet.service.v1.Wallet.ListManualJournalEntries:output_type -> api.wallet.service.v1.ListManualJournalEntriesResponse
-	134, // 403: api.wallet.service.v1.Wallet.ExportManualJournalEntries:output_type -> api.wallet.service.v1.ExportManualJournalEntriesResponse
-	136, // 404: api.wallet.service.v1.Wallet.ListTimeRangeDepositCredits:output_type -> api.wallet.service.v1.ListTimeRangeDepositCreditsResponse
-	138, // 405: api.wallet.service.v1.Wallet.ListUserOverview:output_type -> api.wallet.service.v1.ListUserOverviewResponse
-	140, // 406: api.wallet.service.v1.Wallet.GetUserGameTransactionsSummary:output_type -> api.wallet.service.v1.GetUserGameTransactionsSummaryResponse
-	142, // 407: api.wallet.service.v1.Wallet.CreditFreespinWin:output_type -> api.wallet.service.v1.CreditFreespinWinResponse
-	144, // 408: api.wallet.service.v1.Wallet.CreditFreeBetWin:output_type -> api.wallet.service.v1.CreditFreeBetWinResponse
-	147, // 409: api.wallet.service.v1.Wallet.GetOperatorUserFinancialSummary:output_type -> api.wallet.service.v1.GetOperatorUserFinancialSummaryResponse
-	94,  // 410: api.wallet.service.v1.Wallet.GetWalletConfig:output_type -> api.wallet.service.v1.GetWalletConfigResponse
-	149, // 411: api.wallet.service.v1.Wallet.BatchGetUserFinancialMetrics:output_type -> api.wallet.service.v1.BatchGetUserFinancialMetricsResponse
-	151, // 412: api.wallet.service.v1.Wallet.ManualAdjustCreditTurnoverField:output_type -> api.wallet.service.v1.ManualAdjustCreditTurnoverFieldResponse
-	153, // 413: api.wallet.service.v1.Wallet.ListUserFreeRewards:output_type -> api.wallet.service.v1.ListUserFreeRewardsResponse
-	185, // 414: api.wallet.service.v1.Wallet.ListUserFreeRewardsBO:output_type -> api.wallet.service.v1.ListUserFreeRewardsBOResponse
-	179, // 415: api.wallet.service.v1.Wallet.ListOperatorWithdrawableAmounts:output_type -> api.wallet.service.v1.ListOperatorWithdrawableAmountsResponse
-	181, // 416: api.wallet.service.v1.Wallet.GetOperatorWithdrawCheckInfo:output_type -> api.wallet.service.v1.GetOperatorWithdrawCheckInfoResponse
-	183, // 417: api.wallet.service.v1.Wallet.GetOperatorWithdrawableAmount:output_type -> api.wallet.service.v1.GetOperatorWithdrawableAmountResponse
-	328, // [328:418] is the sub-list for method output_type
-	238, // [238:328] is the sub-list for method input_type
+	225, // 294: api.wallet.service.v1.Wallet.ExportPromoCodeCampaign:input_type -> api.wallet.service.v1.ExportPromoCodeCampaignRequest
+	226, // 295: api.wallet.service.v1.Wallet.GetPromoCodeInfo:input_type -> api.wallet.service.v1.GetPromoCodeInfoRequest
+	227, // 296: api.wallet.service.v1.Wallet.ClaimPromoCode:input_type -> api.wallet.service.v1.ClaimPromoCodeRequest
+	89,  // 297: api.wallet.service.v1.Wallet.GetUserDepositRewardSequence:input_type -> api.wallet.service.v1.GetUserDepositRewardSequenceRequest
+	91,  // 298: api.wallet.service.v1.Wallet.GetGamificationCurrencyConfig:input_type -> api.wallet.service.v1.GetGamificationCurrencyConfigRequest
+	97,  // 299: api.wallet.service.v1.Wallet.UpdateOperatorCurrencyConfig:input_type -> api.wallet.service.v1.UpdateOperatorCurrencyConfigRequest
+	99,  // 300: api.wallet.service.v1.Wallet.UpdateWalletConfig:input_type -> api.wallet.service.v1.UpdateWalletConfigRequest
+	101, // 301: api.wallet.service.v1.Wallet.BonusTransfer:input_type -> api.wallet.service.v1.BonusTransferRequest
+	106, // 302: api.wallet.service.v1.Wallet.AddResponsibleGamblingConfig:input_type -> api.wallet.service.v1.AddResponsibleGamblingConfigRequest
+	108, // 303: api.wallet.service.v1.Wallet.DeleteResponsibleGamblingConfig:input_type -> api.wallet.service.v1.DeleteResponsibleGamblingConfigRequest
+	112, // 304: api.wallet.service.v1.Wallet.ListResponsibleGamblingConfigs:input_type -> api.wallet.service.v1.ListResponsibleGamblingConfigsRequest
+	114, // 305: api.wallet.service.v1.Wallet.GetResponsibleGamblingConfig:input_type -> api.wallet.service.v1.GetResponsibleGamblingConfigRequest
+	116, // 306: api.wallet.service.v1.Wallet.ListCustomerRecords:input_type -> api.wallet.service.v1.ListCustomerRecordsRequest
+	118, // 307: api.wallet.service.v1.Wallet.ExportCustomerRecords:input_type -> api.wallet.service.v1.ExportCustomerRecordsRequest
+	121, // 308: api.wallet.service.v1.Wallet.SetFICAThresholdConfig:input_type -> api.wallet.service.v1.SetFICAThresholdConfigRequest
+	123, // 309: api.wallet.service.v1.Wallet.GetFICAThresholdConfig:input_type -> api.wallet.service.v1.GetFICAThresholdConfigRequest
+	125, // 310: api.wallet.service.v1.Wallet.ListFICAThresholdTransactions:input_type -> api.wallet.service.v1.ListFICAThresholdTransactionsRequest
+	127, // 311: api.wallet.service.v1.Wallet.ExportFICAThresholdTransactions:input_type -> api.wallet.service.v1.ExportFICAThresholdTransactionsRequest
+	129, // 312: api.wallet.service.v1.Wallet.ListBalancesByUserIds:input_type -> api.wallet.service.v1.ListBalancesByUserIdsRequest
+	131, // 313: api.wallet.service.v1.Wallet.ListManualJournalEntries:input_type -> api.wallet.service.v1.ListManualJournalEntriesRequest
+	133, // 314: api.wallet.service.v1.Wallet.ExportManualJournalEntries:input_type -> api.wallet.service.v1.ExportManualJournalEntriesRequest
+	135, // 315: api.wallet.service.v1.Wallet.ListTimeRangeDepositCredits:input_type -> api.wallet.service.v1.ListTimeRangeDepositCreditsRequest
+	137, // 316: api.wallet.service.v1.Wallet.ListUserOverview:input_type -> api.wallet.service.v1.ListUserOverviewRequest
+	139, // 317: api.wallet.service.v1.Wallet.GetUserGameTransactionsSummary:input_type -> api.wallet.service.v1.GetUserGameTransactionsSummaryRequest
+	141, // 318: api.wallet.service.v1.Wallet.CreditFreespinWin:input_type -> api.wallet.service.v1.CreditFreespinWinRequest
+	143, // 319: api.wallet.service.v1.Wallet.CreditFreeBetWin:input_type -> api.wallet.service.v1.CreditFreeBetWinRequest
+	145, // 320: api.wallet.service.v1.Wallet.GetOperatorUserFinancialSummary:input_type -> api.wallet.service.v1.GetOperatorUserFinancialSummaryRequest
+	93,  // 321: api.wallet.service.v1.Wallet.GetWalletConfig:input_type -> api.wallet.service.v1.GetWalletConfigRequest
+	148, // 322: api.wallet.service.v1.Wallet.BatchGetUserFinancialMetrics:input_type -> api.wallet.service.v1.BatchGetUserFinancialMetricsRequest
+	150, // 323: api.wallet.service.v1.Wallet.ManualAdjustCreditTurnoverField:input_type -> api.wallet.service.v1.ManualAdjustCreditTurnoverFieldRequest
+	152, // 324: api.wallet.service.v1.Wallet.ListUserFreeRewards:input_type -> api.wallet.service.v1.ListUserFreeRewardsRequest
+	184, // 325: api.wallet.service.v1.Wallet.ListUserFreeRewardsBO:input_type -> api.wallet.service.v1.ListUserFreeRewardsBORequest
+	177, // 326: api.wallet.service.v1.Wallet.ListOperatorWithdrawableAmounts:input_type -> api.wallet.service.v1.ListOperatorWithdrawableAmountsRequest
+	180, // 327: api.wallet.service.v1.Wallet.GetOperatorWithdrawCheckInfo:input_type -> api.wallet.service.v1.GetOperatorWithdrawCheckInfoRequest
+	182, // 328: api.wallet.service.v1.Wallet.GetOperatorWithdrawableAmount:input_type -> api.wallet.service.v1.GetOperatorWithdrawableAmountRequest
+	1,   // 329: api.wallet.service.v1.Wallet.GetUserBalances:output_type -> api.wallet.service.v1.GetUserBalancesResponse
+	3,   // 330: api.wallet.service.v1.Wallet.GetUserBalance:output_type -> api.wallet.service.v1.GetUserBalanceResponse
+	105, // 331: api.wallet.service.v1.Wallet.GetUserBalanceDetails:output_type -> api.wallet.service.v1.GetUserBalanceDetailsResponse
+	5,   // 332: api.wallet.service.v1.Wallet.Credit:output_type -> api.wallet.service.v1.CreditResponse
+	7,   // 333: api.wallet.service.v1.Wallet.Debit:output_type -> api.wallet.service.v1.DebitResponse
+	10,  // 334: api.wallet.service.v1.Wallet.GameDebit:output_type -> api.wallet.service.v1.GameDebitResponse
+	12,  // 335: api.wallet.service.v1.Wallet.GameCredit:output_type -> api.wallet.service.v1.GameCreditResponse
+	175, // 336: api.wallet.service.v1.Wallet.GameBatchBetAndSettle:output_type -> api.wallet.service.v1.GameBatchBetAndSettleResponse
+	15,  // 337: api.wallet.service.v1.Wallet.Freeze:output_type -> api.wallet.service.v1.FreezeResponse
+	17,  // 338: api.wallet.service.v1.Wallet.Settle:output_type -> api.wallet.service.v1.SettleResponse
+	19,  // 339: api.wallet.service.v1.Wallet.Rollback:output_type -> api.wallet.service.v1.RollbackResponse
+	21,  // 340: api.wallet.service.v1.Wallet.GetWallets:output_type -> api.wallet.service.v1.GetWalletsResponse
+	23,  // 341: api.wallet.service.v1.Wallet.ListWalletBalanceTransactions:output_type -> api.wallet.service.v1.ListWalletBalanceTransactionsResponse
+	25,  // 342: api.wallet.service.v1.Wallet.GetWalletBalanceTransactionsByIds:output_type -> api.wallet.service.v1.GetWalletBalanceTransactionsByIdsResponse
+	27,  // 343: api.wallet.service.v1.Wallet.GetWalletCreditTransactions:output_type -> api.wallet.service.v1.GetWalletCreditTransactionsResponse
+	29,  // 344: api.wallet.service.v1.Wallet.GetExchangeRates:output_type -> api.wallet.service.v1.GetExchangeRatesResponse
+	31,  // 345: api.wallet.service.v1.Wallet.GetExchangeRatesWithBaseCurrency:output_type -> api.wallet.service.v1.GetExchangeRatesWithBaseCurrencyResponse
+	33,  // 346: api.wallet.service.v1.Wallet.GetUserTransactionSummary:output_type -> api.wallet.service.v1.GetUserTransactionSummaryResponse
+	35,  // 347: api.wallet.service.v1.Wallet.ListUserTransactionSummaries:output_type -> api.wallet.service.v1.ListUserTransactionSummariesResponse
+	37,  // 348: api.wallet.service.v1.Wallet.GetBackofficeUserOverviewFromWallet:output_type -> api.wallet.service.v1.GetBackofficeUserOverviewFromWalletResponse
+	40,  // 349: api.wallet.service.v1.Wallet.AddCurrency:output_type -> api.wallet.service.v1.AddCurrencyResponse
+	42,  // 350: api.wallet.service.v1.Wallet.UpdateCurrency:output_type -> api.wallet.service.v1.UpdateCurrencyResponse
+	44,  // 351: api.wallet.service.v1.Wallet.GetCurrencies:output_type -> api.wallet.service.v1.GetCurrenciesResponse
+	46,  // 352: api.wallet.service.v1.Wallet.ListCurrencies:output_type -> api.wallet.service.v1.ListCurrenciesResponse
+	48,  // 353: api.wallet.service.v1.Wallet.UpdateOperatorCurrency:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyResponse
+	50,  // 354: api.wallet.service.v1.Wallet.UpdateUserCurrency:output_type -> api.wallet.service.v1.UpdateUserCurrencyResponse
+	53,  // 355: api.wallet.service.v1.Wallet.ListBottomOperatorBalances:output_type -> api.wallet.service.v1.ListBottomOperatorBalancesResponse
+	55,  // 356: api.wallet.service.v1.Wallet.ListCompanyOperatorBalances:output_type -> api.wallet.service.v1.ListCompanyOperatorBalancesResponse
+	57,  // 357: api.wallet.service.v1.Wallet.OperatorTransfer:output_type -> api.wallet.service.v1.OperatorTransferResponse
+	59,  // 358: api.wallet.service.v1.Wallet.OperatorSwap:output_type -> api.wallet.service.v1.OperatorSwapResponse
+	61,  // 359: api.wallet.service.v1.Wallet.OperatorFreeze:output_type -> api.wallet.service.v1.OperatorFreezeResponse
+	63,  // 360: api.wallet.service.v1.Wallet.OperatorRollback:output_type -> api.wallet.service.v1.OperatorRollbackResponse
+	65,  // 361: api.wallet.service.v1.Wallet.OperatorSettle:output_type -> api.wallet.service.v1.OperatorSettleResponse
+	67,  // 362: api.wallet.service.v1.Wallet.GetOperatorBalance:output_type -> api.wallet.service.v1.GetOperatorBalanceResponse
+	70,  // 363: api.wallet.service.v1.Wallet.ListOperatorBalanceTransactions:output_type -> api.wallet.service.v1.ListOperatorBalanceTransactionsResponse
+	72,  // 364: api.wallet.service.v1.Wallet.OperatorDebit:output_type -> api.wallet.service.v1.OperatorDebitResponse
+	74,  // 365: api.wallet.service.v1.Wallet.OperatorBalanceAdjust:output_type -> api.wallet.service.v1.OperatorBalanceAdjustResponse
+	76,  // 366: api.wallet.service.v1.Wallet.UpdateOperatorBalance:output_type -> api.wallet.service.v1.UpdateOperatorBalanceResponse
+	78,  // 367: api.wallet.service.v1.Wallet.GetOperatorTransactionSummary:output_type -> api.wallet.service.v1.GetOperatorTransactionSummaryResponse
+	170, // 368: api.wallet.service.v1.Wallet.GetCompanyFinancialSummary:output_type -> api.wallet.service.v1.GetCompanyFinancialSummaryResponse
+	80,  // 369: api.wallet.service.v1.Wallet.GetOperatorBalanceTransactionsByIds:output_type -> api.wallet.service.v1.GetOperatorBalanceTransactionsByIdsResponse
+	84,  // 370: api.wallet.service.v1.Wallet.SetDepositRewardSequences:output_type -> api.wallet.service.v1.SetDepositRewardSequencesResponse
+	86,  // 371: api.wallet.service.v1.Wallet.DeleteDepositRewardSequences:output_type -> api.wallet.service.v1.DeleteDepositRewardSequencesResponse
+	88,  // 372: api.wallet.service.v1.Wallet.GetDepositRewardConfig:output_type -> api.wallet.service.v1.GetDepositRewardConfigResponse
+	162, // 373: api.wallet.service.v1.Wallet.SetAppDownloadRewardConfig:output_type -> api.wallet.service.v1.SetAppDownloadRewardConfigResponse
+	164, // 374: api.wallet.service.v1.Wallet.GetAppDownloadRewardConfig:output_type -> api.wallet.service.v1.GetAppDownloadRewardConfigResponse
+	166, // 375: api.wallet.service.v1.Wallet.ClaimAppDownloadReward:output_type -> api.wallet.service.v1.ClaimAppDownloadRewardResponse
+	168, // 376: api.wallet.service.v1.Wallet.GetAppDownloadRewardStatus:output_type -> api.wallet.service.v1.GetAppDownloadRewardStatusResponse
+	228, // 377: api.wallet.service.v1.Wallet.CreatePromoCodeCampaign:output_type -> api.wallet.service.v1.CreatePromoCodeCampaignResponse
+	229, // 378: api.wallet.service.v1.Wallet.UpdatePromoCodeCampaign:output_type -> api.wallet.service.v1.UpdatePromoCodeCampaignResponse
+	230, // 379: api.wallet.service.v1.Wallet.UpdatePromoCodeCampaignStatus:output_type -> api.wallet.service.v1.UpdatePromoCodeCampaignStatusResponse
+	231, // 380: api.wallet.service.v1.Wallet.ListPromoCodeCampaigns:output_type -> api.wallet.service.v1.ListPromoCodeCampaignsResponse
+	232, // 381: api.wallet.service.v1.Wallet.ListPromoCodeCampaignDetails:output_type -> api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse
+	233, // 382: api.wallet.service.v1.Wallet.GenerateOneTimePromoCodes:output_type -> api.wallet.service.v1.GenerateOneTimePromoCodesResponse
+	234, // 383: api.wallet.service.v1.Wallet.GenerateUniversalPromoCodes:output_type -> api.wallet.service.v1.GenerateUniversalPromoCodesResponse
+	235, // 384: api.wallet.service.v1.Wallet.ListUniversalCodeUsages:output_type -> api.wallet.service.v1.ListUniversalCodeUsagesResponse
+	236, // 385: api.wallet.service.v1.Wallet.ExportPromoCodeCampaign:output_type -> api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	237, // 386: api.wallet.service.v1.Wallet.GetPromoCodeInfo:output_type -> api.wallet.service.v1.GetPromoCodeInfoResponse
+	238, // 387: api.wallet.service.v1.Wallet.ClaimPromoCode:output_type -> api.wallet.service.v1.ClaimPromoCodeResponse
+	90,  // 388: api.wallet.service.v1.Wallet.GetUserDepositRewardSequence:output_type -> api.wallet.service.v1.GetUserDepositRewardSequenceResponse
+	96,  // 389: api.wallet.service.v1.Wallet.GetGamificationCurrencyConfig:output_type -> api.wallet.service.v1.GetGamificationCurrencyConfigResponse
+	98,  // 390: api.wallet.service.v1.Wallet.UpdateOperatorCurrencyConfig:output_type -> api.wallet.service.v1.UpdateOperatorCurrencyConfigResponse
+	100, // 391: api.wallet.service.v1.Wallet.UpdateWalletConfig:output_type -> api.wallet.service.v1.UpdateWalletConfigResponse
+	102, // 392: api.wallet.service.v1.Wallet.BonusTransfer:output_type -> api.wallet.service.v1.BonusTransferResponse
+	107, // 393: api.wallet.service.v1.Wallet.AddResponsibleGamblingConfig:output_type -> api.wallet.service.v1.AddResponsibleGamblingConfigResponse
+	109, // 394: api.wallet.service.v1.Wallet.DeleteResponsibleGamblingConfig:output_type -> api.wallet.service.v1.DeleteResponsibleGamblingConfigResponse
+	113, // 395: api.wallet.service.v1.Wallet.ListResponsibleGamblingConfigs:output_type -> api.wallet.service.v1.ListResponsibleGamblingConfigsResponse
+	115, // 396: api.wallet.service.v1.Wallet.GetResponsibleGamblingConfig:output_type -> api.wallet.service.v1.GetResponsibleGamblingConfigResponse
+	117, // 397: api.wallet.service.v1.Wallet.ListCustomerRecords:output_type -> api.wallet.service.v1.ListCustomerRecordsResponse
+	119, // 398: api.wallet.service.v1.Wallet.ExportCustomerRecords:output_type -> api.wallet.service.v1.ExportCustomerRecordsResponse
+	122, // 399: api.wallet.service.v1.Wallet.SetFICAThresholdConfig:output_type -> api.wallet.service.v1.SetFICAThresholdConfigResponse
+	124, // 400: api.wallet.service.v1.Wallet.GetFICAThresholdConfig:output_type -> api.wallet.service.v1.GetFICAThresholdConfigResponse
+	126, // 401: api.wallet.service.v1.Wallet.ListFICAThresholdTransactions:output_type -> api.wallet.service.v1.ListFICAThresholdTransactionsResponse
+	128, // 402: api.wallet.service.v1.Wallet.ExportFICAThresholdTransactions:output_type -> api.wallet.service.v1.ExportFICAThresholdTransactionsResponse
+	130, // 403: api.wallet.service.v1.Wallet.ListBalancesByUserIds:output_type -> api.wallet.service.v1.ListBalancesByUserIdsResponse
+	132, // 404: api.wallet.service.v1.Wallet.ListManualJournalEntries:output_type -> api.wallet.service.v1.ListManualJournalEntriesResponse
+	134, // 405: api.wallet.service.v1.Wallet.ExportManualJournalEntries:output_type -> api.wallet.service.v1.ExportManualJournalEntriesResponse
+	136, // 406: api.wallet.service.v1.Wallet.ListTimeRangeDepositCredits:output_type -> api.wallet.service.v1.ListTimeRangeDepositCreditsResponse
+	138, // 407: api.wallet.service.v1.Wallet.ListUserOverview:output_type -> api.wallet.service.v1.ListUserOverviewResponse
+	140, // 408: api.wallet.service.v1.Wallet.GetUserGameTransactionsSummary:output_type -> api.wallet.service.v1.GetUserGameTransactionsSummaryResponse
+	142, // 409: api.wallet.service.v1.Wallet.CreditFreespinWin:output_type -> api.wallet.service.v1.CreditFreespinWinResponse
+	144, // 410: api.wallet.service.v1.Wallet.CreditFreeBetWin:output_type -> api.wallet.service.v1.CreditFreeBetWinResponse
+	147, // 411: api.wallet.service.v1.Wallet.GetOperatorUserFinancialSummary:output_type -> api.wallet.service.v1.GetOperatorUserFinancialSummaryResponse
+	94,  // 412: api.wallet.service.v1.Wallet.GetWalletConfig:output_type -> api.wallet.service.v1.GetWalletConfigResponse
+	149, // 413: api.wallet.service.v1.Wallet.BatchGetUserFinancialMetrics:output_type -> api.wallet.service.v1.BatchGetUserFinancialMetricsResponse
+	151, // 414: api.wallet.service.v1.Wallet.ManualAdjustCreditTurnoverField:output_type -> api.wallet.service.v1.ManualAdjustCreditTurnoverFieldResponse
+	153, // 415: api.wallet.service.v1.Wallet.ListUserFreeRewards:output_type -> api.wallet.service.v1.ListUserFreeRewardsResponse
+	185, // 416: api.wallet.service.v1.Wallet.ListUserFreeRewardsBO:output_type -> api.wallet.service.v1.ListUserFreeRewardsBOResponse
+	179, // 417: api.wallet.service.v1.Wallet.ListOperatorWithdrawableAmounts:output_type -> api.wallet.service.v1.ListOperatorWithdrawableAmountsResponse
+	181, // 418: api.wallet.service.v1.Wallet.GetOperatorWithdrawCheckInfo:output_type -> api.wallet.service.v1.GetOperatorWithdrawCheckInfoResponse
+	183, // 419: api.wallet.service.v1.Wallet.GetOperatorWithdrawableAmount:output_type -> api.wallet.service.v1.GetOperatorWithdrawableAmountResponse
+	329, // [329:420] is the sub-list for method output_type
+	238, // [238:329] is the sub-list for method input_type
 	238, // [238:238] is the sub-list for extension type_name
 	238, // [238:238] is the sub-list for extension extendee
 	0,   // [0:238] is the sub-list for field type_name

--- a/wallet/service/v1/wallet.pb.go
+++ b/wallet/service/v1/wallet.pb.go
@@ -20268,7 +20268,7 @@ const file_wallet_service_v1_wallet_proto_rawDesc = "" +
 	"updated_at\x18\x15 \x01(\x03R\tupdatedAt\x12!\n" +
 	"\fcompleted_at\x18\x16 \x01(\x03R\vcompletedAt\x12\x1d\n" +
 	"\n" +
-	"revoked_at\x18\x17 \x01(\x03R\trevokedAt2\xa1f\n" +
+	"revoked_at\x18\x17 \x01(\x03R\trevokedAt2\x8bf\n" +
 	"\x06Wallet\x12\x95\x01\n" +
 	"\x0fGetUserBalances\x12-.api.wallet.service.v1.GetUserBalancesRequest\x1a..api.wallet.service.v1.GetUserBalancesResponse\"#\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v1/wallet/balances/list\x12o\n" +
 	"\x0eGetUserBalance\x12,.api.wallet.service.v1.GetUserBalanceRequest\x1a-.api.wallet.service.v1.GetUserBalanceResponse\"\x00\x12\xa9\x01\n" +
@@ -20327,8 +20327,8 @@ const file_wallet_service_v1_wallet_proto_rawDesc = "" +
 	"\x1cListPromoCodeCampaignDetails\x12:.api.wallet.service.v1.ListPromoCodeCampaignDetailsRequest\x1a;.api.wallet.service.v1.ListPromoCodeCampaignDetailsResponse\"\x00\x12\x90\x01\n" +
 	"\x19GenerateOneTimePromoCodes\x127.api.wallet.service.v1.GenerateOneTimePromoCodesRequest\x1a8.api.wallet.service.v1.GenerateOneTimePromoCodesResponse\"\x00\x12\x96\x01\n" +
 	"\x1bGenerateUniversalPromoCodes\x129.api.wallet.service.v1.GenerateUniversalPromoCodesRequest\x1a:.api.wallet.service.v1.GenerateUniversalPromoCodesResponse\"\x00\x12\x8a\x01\n" +
-	"\x17ListUniversalCodeUsages\x125.api.wallet.service.v1.ListUniversalCodeUsagesRequest\x1a6.api.wallet.service.v1.ListUniversalCodeUsagesResponse\"\x00\x12\x8a\x01\n" +
-	"\x17ExportPromoCodeCampaign\x125.api.wallet.service.v1.ExportPromoCodeCampaignRequest\x1a6.api.wallet.service.v1.ExportPromoCodeCampaignResponse\"\x00\x12\x9a\x01\n" +
+	"\x17ListUniversalCodeUsages\x125.api.wallet.service.v1.ListUniversalCodeUsagesRequest\x1a6.api.wallet.service.v1.ListUniversalCodeUsagesResponse\"\x00\x12u\n" +
+	"\x10ExportPromoCodes\x12..api.wallet.service.v1.ExportPromoCodesRequest\x1a/.api.wallet.service.v1.ExportPromoCodesResponse\"\x00\x12\x9a\x01\n" +
 	"\x10GetPromoCodeInfo\x12..api.wallet.service.v1.GetPromoCodeInfoRequest\x1a/.api.wallet.service.v1.GetPromoCodeInfoResponse\"%\x82\xd3\xe4\x93\x02\x1f:\x01*\"\x1a/v1/wallet/promo-code/info\x12\x95\x01\n" +
 	"\x0eClaimPromoCode\x12,.api.wallet.service.v1.ClaimPromoCodeRequest\x1a-.api.wallet.service.v1.ClaimPromoCodeResponse\"&\x82\xd3\xe4\x93\x02 :\x01*\"\x1b/v1/wallet/promo-code/claim\x12\xcb\x01\n" +
 	"\x1cGetUserDepositRewardSequence\x12:.api.wallet.service.v1.GetUserDepositRewardSequenceRequest\x1a;.api.wallet.service.v1.GetUserDepositRewardSequenceResponse\"2\x82\xd3\xe4\x93\x02,:\x01*\"'/v1/wallet/deposit-reward/user-sequence\x12\x9c\x01\n" +
@@ -20604,7 +20604,7 @@ var file_wallet_service_v1_wallet_proto_goTypes = []any{
 	(*GenerateOneTimePromoCodesRequest)(nil),      // 222: api.wallet.service.v1.GenerateOneTimePromoCodesRequest
 	(*GenerateUniversalPromoCodesRequest)(nil),    // 223: api.wallet.service.v1.GenerateUniversalPromoCodesRequest
 	(*ListUniversalCodeUsagesRequest)(nil),        // 224: api.wallet.service.v1.ListUniversalCodeUsagesRequest
-	(*ExportPromoCodeCampaignRequest)(nil),        // 225: api.wallet.service.v1.ExportPromoCodeCampaignRequest
+	(*ExportPromoCodesRequest)(nil),               // 225: api.wallet.service.v1.ExportPromoCodesRequest
 	(*GetPromoCodeInfoRequest)(nil),               // 226: api.wallet.service.v1.GetPromoCodeInfoRequest
 	(*ClaimPromoCodeRequest)(nil),                 // 227: api.wallet.service.v1.ClaimPromoCodeRequest
 	(*CreatePromoCodeCampaignResponse)(nil),       // 228: api.wallet.service.v1.CreatePromoCodeCampaignResponse
@@ -20615,7 +20615,7 @@ var file_wallet_service_v1_wallet_proto_goTypes = []any{
 	(*GenerateOneTimePromoCodesResponse)(nil),     // 233: api.wallet.service.v1.GenerateOneTimePromoCodesResponse
 	(*GenerateUniversalPromoCodesResponse)(nil),   // 234: api.wallet.service.v1.GenerateUniversalPromoCodesResponse
 	(*ListUniversalCodeUsagesResponse)(nil),       // 235: api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	(*ExportPromoCodeCampaignResponse)(nil),       // 236: api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	(*ExportPromoCodesResponse)(nil),              // 236: api.wallet.service.v1.ExportPromoCodesResponse
 	(*GetPromoCodeInfoResponse)(nil),              // 237: api.wallet.service.v1.GetPromoCodeInfoResponse
 	(*ClaimPromoCodeResponse)(nil),                // 238: api.wallet.service.v1.ClaimPromoCodeResponse
 }
@@ -20914,7 +20914,7 @@ var file_wallet_service_v1_wallet_proto_depIdxs = []int32{
 	222, // 291: api.wallet.service.v1.Wallet.GenerateOneTimePromoCodes:input_type -> api.wallet.service.v1.GenerateOneTimePromoCodesRequest
 	223, // 292: api.wallet.service.v1.Wallet.GenerateUniversalPromoCodes:input_type -> api.wallet.service.v1.GenerateUniversalPromoCodesRequest
 	224, // 293: api.wallet.service.v1.Wallet.ListUniversalCodeUsages:input_type -> api.wallet.service.v1.ListUniversalCodeUsagesRequest
-	225, // 294: api.wallet.service.v1.Wallet.ExportPromoCodeCampaign:input_type -> api.wallet.service.v1.ExportPromoCodeCampaignRequest
+	225, // 294: api.wallet.service.v1.Wallet.ExportPromoCodes:input_type -> api.wallet.service.v1.ExportPromoCodesRequest
 	226, // 295: api.wallet.service.v1.Wallet.GetPromoCodeInfo:input_type -> api.wallet.service.v1.GetPromoCodeInfoRequest
 	227, // 296: api.wallet.service.v1.Wallet.ClaimPromoCode:input_type -> api.wallet.service.v1.ClaimPromoCodeRequest
 	89,  // 297: api.wallet.service.v1.Wallet.GetUserDepositRewardSequence:input_type -> api.wallet.service.v1.GetUserDepositRewardSequenceRequest
@@ -21005,7 +21005,7 @@ var file_wallet_service_v1_wallet_proto_depIdxs = []int32{
 	233, // 382: api.wallet.service.v1.Wallet.GenerateOneTimePromoCodes:output_type -> api.wallet.service.v1.GenerateOneTimePromoCodesResponse
 	234, // 383: api.wallet.service.v1.Wallet.GenerateUniversalPromoCodes:output_type -> api.wallet.service.v1.GenerateUniversalPromoCodesResponse
 	235, // 384: api.wallet.service.v1.Wallet.ListUniversalCodeUsages:output_type -> api.wallet.service.v1.ListUniversalCodeUsagesResponse
-	236, // 385: api.wallet.service.v1.Wallet.ExportPromoCodeCampaign:output_type -> api.wallet.service.v1.ExportPromoCodeCampaignResponse
+	236, // 385: api.wallet.service.v1.Wallet.ExportPromoCodes:output_type -> api.wallet.service.v1.ExportPromoCodesResponse
 	237, // 386: api.wallet.service.v1.Wallet.GetPromoCodeInfo:output_type -> api.wallet.service.v1.GetPromoCodeInfoResponse
 	238, // 387: api.wallet.service.v1.Wallet.ClaimPromoCode:output_type -> api.wallet.service.v1.ClaimPromoCodeResponse
 	90,  // 388: api.wallet.service.v1.Wallet.GetUserDepositRewardSequence:output_type -> api.wallet.service.v1.GetUserDepositRewardSequenceResponse

--- a/wallet/service/v1/wallet.proto
+++ b/wallet/service/v1/wallet.proto
@@ -207,6 +207,9 @@ service Wallet {
 
 	rpc ListUniversalCodeUsages(ListUniversalCodeUsagesRequest) returns (ListUniversalCodeUsagesResponse) {}
 
+	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+	rpc ExportPromoCodeCampaign(ExportPromoCodeCampaignRequest) returns (ExportPromoCodeCampaignResponse) {}
+
 	// GetPromoCodeInfo returns promo code information and validates conditions for the current user
 	rpc GetPromoCodeInfo(GetPromoCodeInfoRequest) returns (GetPromoCodeInfoResponse) {
 		option (google.api.http) = {

--- a/wallet/service/v1/wallet.proto
+++ b/wallet/service/v1/wallet.proto
@@ -207,8 +207,8 @@ service Wallet {
 
 	rpc ListUniversalCodeUsages(ListUniversalCodeUsagesRequest) returns (ListUniversalCodeUsagesResponse) {}
 
-	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-	rpc ExportPromoCodeCampaign(ExportPromoCodeCampaignRequest) returns (ExportPromoCodeCampaignResponse) {}
+	// ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+	rpc ExportPromoCodes(ExportPromoCodesRequest) returns (ExportPromoCodesResponse) {}
 
 	// GetPromoCodeInfo returns promo code information and validates conditions for the current user
 	rpc GetPromoCodeInfo(GetPromoCodeInfoRequest) returns (GetPromoCodeInfoResponse) {

--- a/wallet/service/v1/wallet_grpc.pb.go
+++ b/wallet/service/v1/wallet_grpc.pb.go
@@ -75,7 +75,7 @@ const (
 	Wallet_GenerateOneTimePromoCodes_FullMethodName           = "/api.wallet.service.v1.Wallet/GenerateOneTimePromoCodes"
 	Wallet_GenerateUniversalPromoCodes_FullMethodName         = "/api.wallet.service.v1.Wallet/GenerateUniversalPromoCodes"
 	Wallet_ListUniversalCodeUsages_FullMethodName             = "/api.wallet.service.v1.Wallet/ListUniversalCodeUsages"
-	Wallet_ExportPromoCodeCampaign_FullMethodName             = "/api.wallet.service.v1.Wallet/ExportPromoCodeCampaign"
+	Wallet_ExportPromoCodes_FullMethodName                    = "/api.wallet.service.v1.Wallet/ExportPromoCodes"
 	Wallet_GetPromoCodeInfo_FullMethodName                    = "/api.wallet.service.v1.Wallet/GetPromoCodeInfo"
 	Wallet_ClaimPromoCode_FullMethodName                      = "/api.wallet.service.v1.Wallet/ClaimPromoCode"
 	Wallet_GetUserDepositRewardSequence_FullMethodName        = "/api.wallet.service.v1.Wallet/GetUserDepositRewardSequence"
@@ -224,8 +224,8 @@ type WalletClient interface {
 	// GenerateUniversalPromoCodes generates codes for a universal campaign
 	GenerateUniversalPromoCodes(ctx context.Context, in *GenerateUniversalPromoCodesRequest, opts ...grpc.CallOption) (*GenerateUniversalPromoCodesResponse, error)
 	ListUniversalCodeUsages(ctx context.Context, in *ListUniversalCodeUsagesRequest, opts ...grpc.CallOption) (*ListUniversalCodeUsagesResponse, error)
-	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-	ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...grpc.CallOption) (*ExportPromoCodeCampaignResponse, error)
+	// ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+	ExportPromoCodes(ctx context.Context, in *ExportPromoCodesRequest, opts ...grpc.CallOption) (*ExportPromoCodesResponse, error)
 	// GetPromoCodeInfo returns promo code information and validates conditions for the current user
 	GetPromoCodeInfo(ctx context.Context, in *GetPromoCodeInfoRequest, opts ...grpc.CallOption) (*GetPromoCodeInfoResponse, error)
 	// ClaimPromoCode claims promo code reward for the current user
@@ -861,10 +861,10 @@ func (c *walletClient) ListUniversalCodeUsages(ctx context.Context, in *ListUniv
 	return out, nil
 }
 
-func (c *walletClient) ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...grpc.CallOption) (*ExportPromoCodeCampaignResponse, error) {
+func (c *walletClient) ExportPromoCodes(ctx context.Context, in *ExportPromoCodesRequest, opts ...grpc.CallOption) (*ExportPromoCodesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(ExportPromoCodeCampaignResponse)
-	err := c.cc.Invoke(ctx, Wallet_ExportPromoCodeCampaign_FullMethodName, in, out, cOpts...)
+	out := new(ExportPromoCodesResponse)
+	err := c.cc.Invoke(ctx, Wallet_ExportPromoCodes_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1323,8 +1323,8 @@ type WalletServer interface {
 	// GenerateUniversalPromoCodes generates codes for a universal campaign
 	GenerateUniversalPromoCodes(context.Context, *GenerateUniversalPromoCodesRequest) (*GenerateUniversalPromoCodesResponse, error)
 	ListUniversalCodeUsages(context.Context, *ListUniversalCodeUsagesRequest) (*ListUniversalCodeUsagesResponse, error)
-	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
-	ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*ExportPromoCodeCampaignResponse, error)
+	// ExportPromoCodes exports promo codes (one_time codes or universal usages) for a campaign
+	ExportPromoCodes(context.Context, *ExportPromoCodesRequest) (*ExportPromoCodesResponse, error)
 	// GetPromoCodeInfo returns promo code information and validates conditions for the current user
 	GetPromoCodeInfo(context.Context, *GetPromoCodeInfoRequest) (*GetPromoCodeInfoResponse, error)
 	// ClaimPromoCode claims promo code reward for the current user
@@ -1568,8 +1568,8 @@ func (UnimplementedWalletServer) GenerateUniversalPromoCodes(context.Context, *G
 func (UnimplementedWalletServer) ListUniversalCodeUsages(context.Context, *ListUniversalCodeUsagesRequest) (*ListUniversalCodeUsagesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListUniversalCodeUsages not implemented")
 }
-func (UnimplementedWalletServer) ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*ExportPromoCodeCampaignResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method ExportPromoCodeCampaign not implemented")
+func (UnimplementedWalletServer) ExportPromoCodes(context.Context, *ExportPromoCodesRequest) (*ExportPromoCodesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExportPromoCodes not implemented")
 }
 func (UnimplementedWalletServer) GetPromoCodeInfo(context.Context, *GetPromoCodeInfoRequest) (*GetPromoCodeInfoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetPromoCodeInfo not implemented")
@@ -2702,20 +2702,20 @@ func _Wallet_ListUniversalCodeUsages_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Wallet_ExportPromoCodeCampaign_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ExportPromoCodeCampaignRequest)
+func _Wallet_ExportPromoCodes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExportPromoCodesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(WalletServer).ExportPromoCodeCampaign(ctx, in)
+		return srv.(WalletServer).ExportPromoCodes(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: Wallet_ExportPromoCodeCampaign_FullMethodName,
+		FullMethod: Wallet_ExportPromoCodes_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(WalletServer).ExportPromoCodeCampaign(ctx, req.(*ExportPromoCodeCampaignRequest))
+		return srv.(WalletServer).ExportPromoCodes(ctx, req.(*ExportPromoCodesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -3564,8 +3564,8 @@ var Wallet_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _Wallet_ListUniversalCodeUsages_Handler,
 		},
 		{
-			MethodName: "ExportPromoCodeCampaign",
-			Handler:    _Wallet_ExportPromoCodeCampaign_Handler,
+			MethodName: "ExportPromoCodes",
+			Handler:    _Wallet_ExportPromoCodes_Handler,
 		},
 		{
 			MethodName: "GetPromoCodeInfo",

--- a/wallet/service/v1/wallet_grpc.pb.go
+++ b/wallet/service/v1/wallet_grpc.pb.go
@@ -75,6 +75,7 @@ const (
 	Wallet_GenerateOneTimePromoCodes_FullMethodName           = "/api.wallet.service.v1.Wallet/GenerateOneTimePromoCodes"
 	Wallet_GenerateUniversalPromoCodes_FullMethodName         = "/api.wallet.service.v1.Wallet/GenerateUniversalPromoCodes"
 	Wallet_ListUniversalCodeUsages_FullMethodName             = "/api.wallet.service.v1.Wallet/ListUniversalCodeUsages"
+	Wallet_ExportPromoCodeCampaign_FullMethodName             = "/api.wallet.service.v1.Wallet/ExportPromoCodeCampaign"
 	Wallet_GetPromoCodeInfo_FullMethodName                    = "/api.wallet.service.v1.Wallet/GetPromoCodeInfo"
 	Wallet_ClaimPromoCode_FullMethodName                      = "/api.wallet.service.v1.Wallet/ClaimPromoCode"
 	Wallet_GetUserDepositRewardSequence_FullMethodName        = "/api.wallet.service.v1.Wallet/GetUserDepositRewardSequence"
@@ -223,6 +224,8 @@ type WalletClient interface {
 	// GenerateUniversalPromoCodes generates codes for a universal campaign
 	GenerateUniversalPromoCodes(ctx context.Context, in *GenerateUniversalPromoCodesRequest, opts ...grpc.CallOption) (*GenerateUniversalPromoCodesResponse, error)
 	ListUniversalCodeUsages(ctx context.Context, in *ListUniversalCodeUsagesRequest, opts ...grpc.CallOption) (*ListUniversalCodeUsagesResponse, error)
+	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+	ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...grpc.CallOption) (*ExportPromoCodeCampaignResponse, error)
 	// GetPromoCodeInfo returns promo code information and validates conditions for the current user
 	GetPromoCodeInfo(ctx context.Context, in *GetPromoCodeInfoRequest, opts ...grpc.CallOption) (*GetPromoCodeInfoResponse, error)
 	// ClaimPromoCode claims promo code reward for the current user
@@ -858,6 +861,16 @@ func (c *walletClient) ListUniversalCodeUsages(ctx context.Context, in *ListUniv
 	return out, nil
 }
 
+func (c *walletClient) ExportPromoCodeCampaign(ctx context.Context, in *ExportPromoCodeCampaignRequest, opts ...grpc.CallOption) (*ExportPromoCodeCampaignResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExportPromoCodeCampaignResponse)
+	err := c.cc.Invoke(ctx, Wallet_ExportPromoCodeCampaign_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *walletClient) GetPromoCodeInfo(ctx context.Context, in *GetPromoCodeInfoRequest, opts ...grpc.CallOption) (*GetPromoCodeInfoResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetPromoCodeInfoResponse)
@@ -1310,6 +1323,8 @@ type WalletServer interface {
 	// GenerateUniversalPromoCodes generates codes for a universal campaign
 	GenerateUniversalPromoCodes(context.Context, *GenerateUniversalPromoCodesRequest) (*GenerateUniversalPromoCodesResponse, error)
 	ListUniversalCodeUsages(context.Context, *ListUniversalCodeUsagesRequest) (*ListUniversalCodeUsagesResponse, error)
+	// ExportPromoCodeCampaign exports promo code campaign details (one_time codes or universal usages)
+	ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*ExportPromoCodeCampaignResponse, error)
 	// GetPromoCodeInfo returns promo code information and validates conditions for the current user
 	GetPromoCodeInfo(context.Context, *GetPromoCodeInfoRequest) (*GetPromoCodeInfoResponse, error)
 	// ClaimPromoCode claims promo code reward for the current user
@@ -1552,6 +1567,9 @@ func (UnimplementedWalletServer) GenerateUniversalPromoCodes(context.Context, *G
 }
 func (UnimplementedWalletServer) ListUniversalCodeUsages(context.Context, *ListUniversalCodeUsagesRequest) (*ListUniversalCodeUsagesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListUniversalCodeUsages not implemented")
+}
+func (UnimplementedWalletServer) ExportPromoCodeCampaign(context.Context, *ExportPromoCodeCampaignRequest) (*ExportPromoCodeCampaignResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExportPromoCodeCampaign not implemented")
 }
 func (UnimplementedWalletServer) GetPromoCodeInfo(context.Context, *GetPromoCodeInfoRequest) (*GetPromoCodeInfoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetPromoCodeInfo not implemented")
@@ -2684,6 +2702,24 @@ func _Wallet_ListUniversalCodeUsages_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Wallet_ExportPromoCodeCampaign_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExportPromoCodeCampaignRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WalletServer).ExportPromoCodeCampaign(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Wallet_ExportPromoCodeCampaign_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WalletServer).ExportPromoCodeCampaign(ctx, req.(*ExportPromoCodeCampaignRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Wallet_GetPromoCodeInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetPromoCodeInfoRequest)
 	if err := dec(in); err != nil {
@@ -3526,6 +3562,10 @@ var Wallet_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListUniversalCodeUsages",
 			Handler:    _Wallet_ListUniversalCodeUsages_Handler,
+		},
+		{
+			MethodName: "ExportPromoCodeCampaign",
+			Handler:    _Wallet_ExportPromoCodeCampaign_Handler,
 		},
 		{
 			MethodName: "GetPromoCodeInfo",


### PR DESCRIPTION
## Summary
- Add unified `ExportPromoCodes` RPC that auto-detects campaign type (one_time/universal) and exports corresponding promo code data
- Supports filters: `user_id`, `status` (one_time only), `code`
- BO endpoint: `POST /v1/backoffice/wallet/promo-code/campaign/export`
- Add `REPORT_EXPORT_TYPE_PROMO_CODES` constant in `pkg/tasks`

## Test plan
- [ ] `make api` generates without errors
- [ ] Wallet service and backoffice service can compile with the new proto types
- [ ] End-to-end test via BO export endpoint after wallet/backoffice service implementations are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)