### PR TITLE
feat: expose push-svc OTP callback route via gateway

### DIFF
--- a/deploy/httproute-dev.yaml
+++ b/deploy/httproute-dev.yaml
@@ -106,3 +106,11 @@ spec:
         - name: jackpot-svc
           port: 8000
           weight: 1
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/v1/push/otp/providers"
+      backendRefs:
+        - name: push-svc
+          port: 8000
+          weight: 1

--- a/deploy/httproute-prod.yaml
+++ b/deploy/httproute-prod.yaml
@@ -106,6 +106,14 @@ spec:
     - name: jackpot-svc
       port: 8000
       weight: 1
+  - matches:
+    - path:
+        type: PathPrefix
+        value: "/v1/push/otp/providers"
+    backendRefs:
+    - name: push-svc
+      port: 8000
+      weight: 1
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute

--- a/deploy/httproute-stg.yaml
+++ b/deploy/httproute-stg.yaml
@@ -106,3 +106,11 @@ spec:
         - name: jackpot-svc
           port: 8000
           weight: 1
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/v1/push/otp/providers"
+      backendRefs:
+        - name: push-svc
+          port: 8000
+          weight: 1


### PR DESCRIPTION
## Summary
- Add `/v1/push/otp/providers` prefix route → `push-svc:8000` on dev/stg/prod HTTPRoutes
- Required for EngageLab OTP delivery callbacks to reach push service through the API gateway
- Companion PR: infigaming-com/meepo-push-service#105

## Test plan
- [ ] Apply httproute on dev, verify `POST https://dev.meepoapi.xyz/v1/push/otp/providers/123/callback/engagelab` reaches push-svc (empty body → 200)
- [ ] Verify other paths under `/v1/push/` that don't match are not routed

🤖 Generated with [Claude Code](https://claude.com/claude-code)