### PR TITLE
docs: add comments for PlayerListTickets and PlayerGetTicket APIs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10183,6 +10183,9 @@ paths:
         post:
             tags:
                 - Review
+            description: |-
+                PlayerGetTicket returns the detail of a single withdrawal ticket owned by the current player.
+                 Returns NOT_FOUND if the ticket does not exist or does not belong to the caller.
             operationId: Review_PlayerGetTicket
             requestBody:
                 content:
@@ -10201,7 +10204,9 @@ paths:
         post:
             tags:
                 - Review
-            description: Player-facing endpoints
+            description: |-
+                PlayerListTickets returns a paginated list of the current player's withdrawal tickets.
+                 Supports optional filtering by status. Results are ordered by created_at DESC.
             operationId: Review_PlayerListTickets
             requestBody:
                 content:
@@ -30721,37 +30726,57 @@ components:
             properties:
                 ticketId:
                     type: string
+                    description: Ticket ID to retrieve. Must belong to the current player.
+            description: PlayerGetTicket - returns the detail of a single withdrawal ticket owned by the current player.
         api.review.service.v1.PlayerGetTicketResponse:
             type: object
             properties:
                 ticketId:
                     type: string
+                    description: Unique ticket identifier
                 status:
                     type: string
+                    description: 'Review status: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"'
                 amount:
                     type: string
+                    description: Withdrawal amount in the original currency (decimal string)
                 currency:
                     type: string
+                    description: Currency code (e.g. "USD", "BRL", "USDT")
                 paymentStatus:
                     type: string
+                    description: 'Payment channel processing status: "pending", "processing", "success", "failed"'
                 playerComment:
                     type: string
+                    description: Reviewer comment visible to the player (typically set on rejection)
                 createdAt:
                     type: string
+                    description: Ticket creation time (Unix timestamp in seconds)
                 reviewedAt:
                     type: string
+                    description: Time when the ticket was reviewed (Unix timestamp in seconds, 0 if not yet reviewed)
+            description: |-
+                PlayerGetTicketResponse - ticket detail visible to the player.
+                 Fields are identical to PlayerListTicketsResponse.Ticket for consistency.
         api.review.service.v1.PlayerListTicketsRequest:
             type: object
             properties:
                 status:
                     type: string
+                    description: |-
+                        Filter by ticket review status. If not set, returns all statuses.
+                         Values: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"
                 page:
                     type: integer
+                    description: Page number, 1-based. Defaults to 1.
                     format: int32
                 pageSize:
                     type: integer
+                    description: Number of tickets per page. Defaults to 20, max 100.
                     format: int32
-            description: Player-facing ticket messages
+            description: |-
+                PlayerListTickets - returns a paginated list of the current player's withdrawal tickets.
+                 The player identity is extracted from the JWT token by the gateway; no user_id is passed explicitly.
         api.review.service.v1.PlayerListTicketsResponse:
             type: object
             properties:
@@ -30761,32 +30786,52 @@ components:
                         $ref: '#/components/schemas/api.review.service.v1.PlayerListTicketsResponse_Ticket'
                 page:
                     type: integer
+                    description: Current page number
                     format: int32
                 pageSize:
                     type: integer
+                    description: Page size used
                     format: int32
                 totalCount:
                     type: integer
+                    description: Total number of tickets matching the filter
                     format: int32
         api.review.service.v1.PlayerListTicketsResponse_Ticket:
             type: object
             properties:
                 ticketId:
                     type: string
+                    description: Unique ticket identifier
                 status:
                     type: string
+                    description: |-
+                        Review status: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"
+                           - pending: awaiting review
+                           - approved: approved by reviewer, proceeding to payment
+                           - rejected: rejected by reviewer (see player_comment for reason)
+                           - manual_payout: reviewer chose manual payout outside the system
+                           - paying: payment in progress via payment channel
+                           - paid: payment completed successfully
+                           - failed: payment failed after approval
                 amount:
                     type: string
+                    description: Withdrawal amount in the original currency (decimal string, e.g. "100.50")
                 currency:
                     type: string
+                    description: Currency code (e.g. "USD", "BRL", "USDT")
                 paymentStatus:
                     type: string
+                    description: 'Payment channel processing status: "pending", "processing", "success", "failed"'
                 playerComment:
                     type: string
+                    description: Reviewer comment visible to the player (typically set on rejection to explain the reason)
                 createdAt:
                     type: string
+                    description: Ticket creation time (Unix timestamp in seconds)
                 reviewedAt:
                     type: string
+                    description: Time when the ticket was reviewed (Unix timestamp in seconds, 0 if not yet reviewed)
+            description: Ticket summary visible to the player.
         api.review.service.v1.PrecheckWithdrawApprovalResponse:
             type: object
             properties:

--- a/review/service/v1/review.pb.go
+++ b/review/service/v1/review.pb.go
@@ -1466,12 +1466,17 @@ func (x *WithdrawApprovalCheck) GetRequestValue() string {
 	return ""
 }
 
-// Player-facing ticket messages
+// PlayerListTickets - returns a paginated list of the current player's withdrawal tickets.
+// The player identity is extracted from the JWT token by the gateway; no user_id is passed explicitly.
 type PlayerListTicketsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        *string                `protobuf:"bytes,1,opt,name=status,proto3,oneof" json:"status,omitempty"`
-	Page          *int32                 `protobuf:"varint,2,opt,name=page,proto3,oneof" json:"page,omitempty"`
-	PageSize      *int32                 `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3,oneof" json:"page_size,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Filter by ticket review status. If not set, returns all statuses.
+	// Values: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"
+	Status *string `protobuf:"bytes,1,opt,name=status,proto3,oneof" json:"status,omitempty"`
+	// Page number, 1-based. Defaults to 1.
+	Page *int32 `protobuf:"varint,2,opt,name=page,proto3,oneof" json:"page,omitempty"`
+	// Number of tickets per page. Defaults to 20, max 100.
+	PageSize      *int32 `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3,oneof" json:"page_size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1528,11 +1533,14 @@ func (x *PlayerListTicketsRequest) GetPageSize() int32 {
 }
 
 type PlayerListTicketsResponse struct {
-	state         protoimpl.MessageState              `protogen:"open.v1"`
-	Tickets       []*PlayerListTicketsResponse_Ticket `protobuf:"bytes,1,rep,name=tickets,proto3" json:"tickets,omitempty"`
-	Page          int32                               `protobuf:"varint,2,opt,name=page,proto3" json:"page,omitempty"`
-	PageSize      int32                               `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	TotalCount    int32                               `protobuf:"varint,4,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
+	state   protoimpl.MessageState              `protogen:"open.v1"`
+	Tickets []*PlayerListTicketsResponse_Ticket `protobuf:"bytes,1,rep,name=tickets,proto3" json:"tickets,omitempty"`
+	// Current page number
+	Page int32 `protobuf:"varint,2,opt,name=page,proto3" json:"page,omitempty"`
+	// Page size used
+	PageSize int32 `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// Total number of tickets matching the filter
+	TotalCount    int32 `protobuf:"varint,4,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1595,9 +1603,11 @@ func (x *PlayerListTicketsResponse) GetTotalCount() int32 {
 	return 0
 }
 
+// PlayerGetTicket - returns the detail of a single withdrawal ticket owned by the current player.
 type PlayerGetTicketRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TicketId      int64                  `protobuf:"varint,1,opt,name=ticket_id,json=ticketId,proto3" json:"ticket_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Ticket ID to retrieve. Must belong to the current player.
+	TicketId      int64 `protobuf:"varint,1,opt,name=ticket_id,json=ticketId,proto3" json:"ticket_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1639,16 +1649,26 @@ func (x *PlayerGetTicketRequest) GetTicketId() int64 {
 	return 0
 }
 
+// PlayerGetTicketResponse - ticket detail visible to the player.
+// Fields are identical to PlayerListTicketsResponse.Ticket for consistency.
 type PlayerGetTicketResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TicketId      int64                  `protobuf:"varint,1,opt,name=ticket_id,json=ticketId,proto3" json:"ticket_id,omitempty"`
-	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
-	Amount        string                 `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount,omitempty"`
-	Currency      string                 `protobuf:"bytes,4,opt,name=currency,proto3" json:"currency,omitempty"`
-	PaymentStatus string                 `protobuf:"bytes,5,opt,name=payment_status,json=paymentStatus,proto3" json:"payment_status,omitempty"`
-	PlayerComment string                 `protobuf:"bytes,6,opt,name=player_comment,json=playerComment,proto3" json:"player_comment,omitempty"`
-	CreatedAt     int64                  `protobuf:"varint,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	ReviewedAt    int64                  `protobuf:"varint,8,opt,name=reviewed_at,json=reviewedAt,proto3" json:"reviewed_at,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique ticket identifier
+	TicketId int64 `protobuf:"varint,1,opt,name=ticket_id,json=ticketId,proto3" json:"ticket_id,omitempty"`
+	// Review status: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"
+	Status string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	// Withdrawal amount in the original currency (decimal string)
+	Amount string `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	// Currency code (e.g. "USD", "BRL", "USDT")
+	Currency string `protobuf:"bytes,4,opt,name=currency,proto3" json:"currency,omitempty"`
+	// Payment channel processing status: "pending", "processing", "success", "failed"
+	PaymentStatus string `protobuf:"bytes,5,opt,name=payment_status,json=paymentStatus,proto3" json:"payment_status,omitempty"`
+	// Reviewer comment visible to the player (typically set on rejection)
+	PlayerComment string `protobuf:"bytes,6,opt,name=player_comment,json=playerComment,proto3" json:"player_comment,omitempty"`
+	// Ticket creation time (Unix timestamp in seconds)
+	CreatedAt int64 `protobuf:"varint,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// Time when the ticket was reviewed (Unix timestamp in seconds, 0 if not yet reviewed)
+	ReviewedAt    int64 `protobuf:"varint,8,opt,name=reviewed_at,json=reviewedAt,proto3" json:"reviewed_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3319,16 +3339,32 @@ func (x *GetOperatorTicketResponse_WalletTransactionSummary) GetTotalPendingRepo
 	return ""
 }
 
+// Ticket summary visible to the player.
 type PlayerListTicketsResponse_Ticket struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TicketId      int64                  `protobuf:"varint,1,opt,name=ticket_id,json=ticketId,proto3" json:"ticket_id,omitempty"`
-	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
-	Amount        string                 `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount,omitempty"`
-	Currency      string                 `protobuf:"bytes,4,opt,name=currency,proto3" json:"currency,omitempty"`
-	PaymentStatus string                 `protobuf:"bytes,5,opt,name=payment_status,json=paymentStatus,proto3" json:"payment_status,omitempty"`
-	PlayerComment string                 `protobuf:"bytes,6,opt,name=player_comment,json=playerComment,proto3" json:"player_comment,omitempty"`
-	CreatedAt     int64                  `protobuf:"varint,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	ReviewedAt    int64                  `protobuf:"varint,8,opt,name=reviewed_at,json=reviewedAt,proto3" json:"reviewed_at,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique ticket identifier
+	TicketId int64 `protobuf:"varint,1,opt,name=ticket_id,json=ticketId,proto3" json:"ticket_id,omitempty"`
+	// Review status: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"
+	//   - pending: awaiting review
+	//   - approved: approved by reviewer, proceeding to payment
+	//   - rejected: rejected by reviewer (see player_comment for reason)
+	//   - manual_payout: reviewer chose manual payout outside the system
+	//   - paying: payment in progress via payment channel
+	//   - paid: payment completed successfully
+	//   - failed: payment failed after approval
+	Status string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	// Withdrawal amount in the original currency (decimal string, e.g. "100.50")
+	Amount string `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	// Currency code (e.g. "USD", "BRL", "USDT")
+	Currency string `protobuf:"bytes,4,opt,name=currency,proto3" json:"currency,omitempty"`
+	// Payment channel processing status: "pending", "processing", "success", "failed"
+	PaymentStatus string `protobuf:"bytes,5,opt,name=payment_status,json=paymentStatus,proto3" json:"payment_status,omitempty"`
+	// Reviewer comment visible to the player (typically set on rejection to explain the reason)
+	PlayerComment string `protobuf:"bytes,6,opt,name=player_comment,json=playerComment,proto3" json:"player_comment,omitempty"`
+	// Ticket creation time (Unix timestamp in seconds)
+	CreatedAt int64 `protobuf:"varint,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// Time when the ticket was reviewed (Unix timestamp in seconds, 0 if not yet reviewed)
+	ReviewedAt    int64 `protobuf:"varint,8,opt,name=reviewed_at,json=reviewedAt,proto3" json:"reviewed_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/review/service/v1/review.proto
+++ b/review/service/v1/review.proto
@@ -37,13 +37,16 @@ service Review {
 	// PrecheckUserWithdrawApproval checks if a user/affiliate withdraw ticket can be safely approved
 	rpc PrecheckUserWithdrawApproval(PrecheckWithdrawApprovalRequest) returns (PrecheckWithdrawApprovalResponse) {}
 
-	// Player-facing endpoints
+	// PlayerListTickets returns a paginated list of the current player's withdrawal tickets.
+	// Supports optional filtering by status. Results are ordered by created_at DESC.
 	rpc PlayerListTickets(PlayerListTicketsRequest) returns (PlayerListTicketsResponse) {
 		option (google.api.http) = {
 			post: "/v1/review/tickets/list"
 			body: "*"
 		};
 	}
+	// PlayerGetTicket returns the detail of a single withdrawal ticket owned by the current player.
+	// Returns NOT_FOUND if the ticket does not exist or does not belong to the caller.
 	rpc PlayerGetTicket(PlayerGetTicketRequest) returns (PlayerGetTicketResponse) {
 		option (google.api.http) = {
 			post: "/v1/review/tickets/get"
@@ -373,41 +376,77 @@ message WithdrawApprovalCheck {
 	string request_value = 5;
 }
 
-// Player-facing ticket messages
+// PlayerListTickets - returns a paginated list of the current player's withdrawal tickets.
+// The player identity is extracted from the JWT token by the gateway; no user_id is passed explicitly.
 message PlayerListTicketsRequest {
+	// Filter by ticket review status. If not set, returns all statuses.
+	// Values: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"
 	optional string status = 1;
+	// Page number, 1-based. Defaults to 1.
 	optional int32 page = 2;
+	// Number of tickets per page. Defaults to 20, max 100.
 	optional int32 page_size = 3;
 }
 
 message PlayerListTicketsResponse {
+	// Ticket summary visible to the player.
 	message Ticket {
+		// Unique ticket identifier
 		int64 ticket_id = 1;
+		// Review status: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"
+		//   - pending: awaiting review
+		//   - approved: approved by reviewer, proceeding to payment
+		//   - rejected: rejected by reviewer (see player_comment for reason)
+		//   - manual_payout: reviewer chose manual payout outside the system
+		//   - paying: payment in progress via payment channel
+		//   - paid: payment completed successfully
+		//   - failed: payment failed after approval
 		string status = 2;
+		// Withdrawal amount in the original currency (decimal string, e.g. "100.50")
 		string amount = 3;
+		// Currency code (e.g. "USD", "BRL", "USDT")
 		string currency = 4;
+		// Payment channel processing status: "pending", "processing", "success", "failed"
 		string payment_status = 5;
+		// Reviewer comment visible to the player (typically set on rejection to explain the reason)
 		string player_comment = 6;
+		// Ticket creation time (Unix timestamp in seconds)
 		int64 created_at = 7;
+		// Time when the ticket was reviewed (Unix timestamp in seconds, 0 if not yet reviewed)
 		int64 reviewed_at = 8;
 	}
 	repeated Ticket tickets = 1;
+	// Current page number
 	int32 page = 2;
+	// Page size used
 	int32 page_size = 3;
+	// Total number of tickets matching the filter
 	int32 total_count = 4;
 }
 
+// PlayerGetTicket - returns the detail of a single withdrawal ticket owned by the current player.
 message PlayerGetTicketRequest {
+	// Ticket ID to retrieve. Must belong to the current player.
 	int64 ticket_id = 1;
 }
 
+// PlayerGetTicketResponse - ticket detail visible to the player.
+// Fields are identical to PlayerListTicketsResponse.Ticket for consistency.
 message PlayerGetTicketResponse {
+	// Unique ticket identifier
 	int64 ticket_id = 1;
+	// Review status: "pending", "approved", "rejected", "manual_payout", "paying", "paid", "failed"
 	string status = 2;
+	// Withdrawal amount in the original currency (decimal string)
 	string amount = 3;
+	// Currency code (e.g. "USD", "BRL", "USDT")
 	string currency = 4;
+	// Payment channel processing status: "pending", "processing", "success", "failed"
 	string payment_status = 5;
+	// Reviewer comment visible to the player (typically set on rejection)
 	string player_comment = 6;
+	// Ticket creation time (Unix timestamp in seconds)
 	int64 created_at = 7;
+	// Time when the ticket was reviewed (Unix timestamp in seconds, 0 if not yet reviewed)
 	int64 reviewed_at = 8;
 }

--- a/review/service/v1/review_grpc.pb.go
+++ b/review/service/v1/review_grpc.pb.go
@@ -54,8 +54,11 @@ type ReviewClient interface {
 	GetOperatorTicket(ctx context.Context, in *GetOperatorTicketRequest, opts ...grpc.CallOption) (*GetOperatorTicketResponse, error)
 	// PrecheckUserWithdrawApproval checks if a user/affiliate withdraw ticket can be safely approved
 	PrecheckUserWithdrawApproval(ctx context.Context, in *PrecheckWithdrawApprovalRequest, opts ...grpc.CallOption) (*PrecheckWithdrawApprovalResponse, error)
-	// Player-facing endpoints
+	// PlayerListTickets returns a paginated list of the current player's withdrawal tickets.
+	// Supports optional filtering by status. Results are ordered by created_at DESC.
 	PlayerListTickets(ctx context.Context, in *PlayerListTicketsRequest, opts ...grpc.CallOption) (*PlayerListTicketsResponse, error)
+	// PlayerGetTicket returns the detail of a single withdrawal ticket owned by the current player.
+	// Returns NOT_FOUND if the ticket does not exist or does not belong to the caller.
 	PlayerGetTicket(ctx context.Context, in *PlayerGetTicketRequest, opts ...grpc.CallOption) (*PlayerGetTicketResponse, error)
 }
 
@@ -217,8 +220,11 @@ type ReviewServer interface {
 	GetOperatorTicket(context.Context, *GetOperatorTicketRequest) (*GetOperatorTicketResponse, error)
 	// PrecheckUserWithdrawApproval checks if a user/affiliate withdraw ticket can be safely approved
 	PrecheckUserWithdrawApproval(context.Context, *PrecheckWithdrawApprovalRequest) (*PrecheckWithdrawApprovalResponse, error)
-	// Player-facing endpoints
+	// PlayerListTickets returns a paginated list of the current player's withdrawal tickets.
+	// Supports optional filtering by status. Results are ordered by created_at DESC.
 	PlayerListTickets(context.Context, *PlayerListTicketsRequest) (*PlayerListTicketsResponse, error)
+	// PlayerGetTicket returns the detail of a single withdrawal ticket owned by the current player.
+	// Returns NOT_FOUND if the ticket does not exist or does not belong to the caller.
 	PlayerGetTicket(context.Context, *PlayerGetTicketRequest) (*PlayerGetTicketResponse, error)
 	mustEmbedUnimplementedReviewServer()
 }

--- a/review/service/v1/review_http.pb.go
+++ b/review/service/v1/review_http.pb.go
@@ -25,8 +25,11 @@ const OperationReviewPlayerListTickets = "/api.review.service.v1.Review/PlayerLi
 
 type ReviewHTTPServer interface {
 	CreateWithdraw(context.Context, *CreateWithdrawRequest) (*CreateWithdrawResponse, error)
+	// PlayerGetTicket PlayerGetTicket returns the detail of a single withdrawal ticket owned by the current player.
+	// Returns NOT_FOUND if the ticket does not exist or does not belong to the caller.
 	PlayerGetTicket(context.Context, *PlayerGetTicketRequest) (*PlayerGetTicketResponse, error)
-	// PlayerListTickets Player-facing endpoints
+	// PlayerListTickets PlayerListTickets returns a paginated list of the current player's withdrawal tickets.
+	// Supports optional filtering by status. Results are ordered by created_at DESC.
 	PlayerListTickets(context.Context, *PlayerListTicketsRequest) (*PlayerListTicketsResponse, error)
 }
 
@@ -105,8 +108,11 @@ func _Review_PlayerGetTicket0_HTTP_Handler(srv ReviewHTTPServer) func(ctx http.C
 
 type ReviewHTTPClient interface {
 	CreateWithdraw(ctx context.Context, req *CreateWithdrawRequest, opts ...http.CallOption) (rsp *CreateWithdrawResponse, err error)
+	// PlayerGetTicket PlayerGetTicket returns the detail of a single withdrawal ticket owned by the current player.
+	// Returns NOT_FOUND if the ticket does not exist or does not belong to the caller.
 	PlayerGetTicket(ctx context.Context, req *PlayerGetTicketRequest, opts ...http.CallOption) (rsp *PlayerGetTicketResponse, err error)
-	// PlayerListTickets Player-facing endpoints
+	// PlayerListTickets PlayerListTickets returns a paginated list of the current player's withdrawal tickets.
+	// Supports optional filtering by status. Results are ordered by created_at DESC.
 	PlayerListTickets(ctx context.Context, req *PlayerListTicketsRequest, opts ...http.CallOption) (rsp *PlayerListTicketsResponse, err error)
 }
 
@@ -131,6 +137,8 @@ func (c *ReviewHTTPClientImpl) CreateWithdraw(ctx context.Context, in *CreateWit
 	return &out, nil
 }
 
+// PlayerGetTicket PlayerGetTicket returns the detail of a single withdrawal ticket owned by the current player.
+// Returns NOT_FOUND if the ticket does not exist or does not belong to the caller.
 func (c *ReviewHTTPClientImpl) PlayerGetTicket(ctx context.Context, in *PlayerGetTicketRequest, opts ...http.CallOption) (*PlayerGetTicketResponse, error) {
 	var out PlayerGetTicketResponse
 	pattern := "/v1/review/tickets/get"
@@ -144,7 +152,8 @@ func (c *ReviewHTTPClientImpl) PlayerGetTicket(ctx context.Context, in *PlayerGe
 	return &out, nil
 }
 
-// PlayerListTickets Player-facing endpoints
+// PlayerListTickets PlayerListTickets returns a paginated list of the current player's withdrawal tickets.
+// Supports optional filtering by status. Results are ordered by created_at DESC.
 func (c *ReviewHTTPClientImpl) PlayerListTickets(ctx context.Context, in *PlayerListTicketsRequest, opts ...http.CallOption) (*PlayerListTicketsResponse, error) {
 	var out PlayerListTicketsResponse
 	pattern := "/v1/review/tickets/list"


### PR DESCRIPTION
## Summary

- 为 `PlayerListTickets` 和 `PlayerGetTicket` 两个 player-facing 接口添加详细注释，参照 CRM proto 的注释格式
- RPC 方法描述（用途、认证方式、错误行为）
- 字段级注释：status/payment_status 枚举值及含义、amount 格式、timestamp 语义、分页默认值

## Changed Files

| File | Changes |
|------|---------|
| `review/service/v1/review.proto` | 添加 RPC + message 字段注释 |
| `review/service/v1/review.pb.go` | protobuf 生成代码更新 |
| `review/service/v1/review_grpc.pb.go` | gRPC 生成代码更新 |
| `review/service/v1/review_http.pb.go` | HTTP 生成代码更新 |
| `openapi.yaml` | OpenAPI spec 更新（注释同步到 description） |