### PR TITLE
feat: route /connection to centrifugo-svc in oracle-dev

### DIFF
--- a/deploy/httproute-oracle-dev.yaml
+++ b/deploy/httproute-oracle-dev.yaml
@@ -13,6 +13,15 @@ spec:
   - matches:
     - path:
         type: PathPrefix
+        value: "/connection"
+    backendRefs:
+    - name: centrifugo-svc
+      namespace: oracle-dev
+      port: 8000
+      weight: 1
+  - matches:
+    - path:
+        type: PathPrefix
         value: "/v1"
     - path:
         type: PathPrefix


### PR DESCRIPTION
## Summary
- oracle-dev HTTPRoute 缺少 `/connection` 规则，导致 `prediction.meepoapi.xyz` 上的 Centrifugo WebSocket 无法经 Gateway 路由到 `centrifugo-svc`
- 参照 `httproute-invoker-dev.yaml` 的做法，新增 `/connection` → `centrifugo-svc:8000` 的 backendRef

## Test plan
- [ ] apply 后访问 `wss://prediction.meepoapi.xyz/connection/websocket` 能建立连接
- [ ] 现有 `/v1` 和 `/sessions` 路由不受影响