### PR TITLE
feat: add EMAIL_ALREADY_VERIFIED / PHONE_ALREADY_VERIFIED error codes

### DIFF
--- a/user/service/v1/error_reason.pb.go
+++ b/user/service/v1/error_reason.pb.go
@@ -211,6 +211,11 @@ const (
 	ErrorReason_PHONE_ALREADY_EXISTS      ErrorReason = 10451
 	ErrorReason_INVALID_PHONE_NUMBER      ErrorReason = 10452
 	ErrorReason_INVALID_OPERATOR_NAME     ErrorReason = 10500
+	// KYC / contact rebind guards. Returned when a user tries to re-run the
+	// verify flow on a contact (email / mobile) that is already verified,
+	// which would otherwise silently overwrite the previously bound value.
+	ErrorReason_EMAIL_ALREADY_VERIFIED ErrorReason = 10501
+	ErrorReason_PHONE_ALREADY_VERIFIED ErrorReason = 10502
 )
 
 // Enum value maps for ErrorReason.
@@ -396,6 +401,8 @@ var (
 		10451: "PHONE_ALREADY_EXISTS",
 		10452: "INVALID_PHONE_NUMBER",
 		10500: "INVALID_OPERATOR_NAME",
+		10501: "EMAIL_ALREADY_VERIFIED",
+		10502: "PHONE_ALREADY_VERIFIED",
 	}
 	ErrorReason_value = map[string]int32{
 		"UNSPECIFIED":                                    0,
@@ -578,6 +585,8 @@ var (
 		"PHONE_ALREADY_EXISTS":                           10451,
 		"INVALID_PHONE_NUMBER":                           10452,
 		"INVALID_OPERATOR_NAME":                          10500,
+		"EMAIL_ALREADY_VERIFIED":                         10501,
+		"PHONE_ALREADY_VERIFIED":                         10502,
 	}
 )
 
@@ -612,7 +621,7 @@ var File_user_service_v1_error_reason_proto protoreflect.FileDescriptor
 
 const file_user_service_v1_error_reason_proto_rawDesc = "" +
 	"\n" +
-	"\"user/service/v1/error_reason.proto\x12\x13api.user.service.v1\x1a\x13errors/errors.proto*\xb2/\n" +
+	"\"user/service/v1/error_reason.proto\x12\x13api.user.service.v1\x1a\x13errors/errors.proto*\xf8/\n" +
 	"\vErrorReason\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12#\n" +
 	"\x1eUSER_INFO_NOT_FOUND_IN_CONTEXT\x10\x90N\x12&\n" +
@@ -793,7 +802,9 @@ const file_user_service_v1_error_reason_proto_rawDesc = "" +
 	"\x19PHONE_VERIFICATION_FAILED\x10\xd2Q\x12\x19\n" +
 	"\x14PHONE_ALREADY_EXISTS\x10\xd3Q\x12\x19\n" +
 	"\x14INVALID_PHONE_NUMBER\x10\xd4Q\x12\x1a\n" +
-	"\x15INVALID_OPERATOR_NAME\x10\x84R\x1a\x04\xa0E\xf4\x03BO\n" +
+	"\x15INVALID_OPERATOR_NAME\x10\x84R\x12!\n" +
+	"\x16EMAIL_ALREADY_VERIFIED\x10\x85R\x1a\x04\xa8E\x99\x03\x12!\n" +
+	"\x16PHONE_ALREADY_VERIFIED\x10\x86R\x1a\x04\xa8E\x99\x03\x1a\x04\xa0E\xf4\x03BO\n" +
 	"\x13api.user.service.v1P\x01Z6github.com/infigaming-com/meepo-api/user/service/v1;v1b\x06proto3"
 
 var (

--- a/user/service/v1/error_reason.proto
+++ b/user/service/v1/error_reason.proto
@@ -204,4 +204,10 @@ enum ErrorReason {
   INVALID_PHONE_NUMBER = 10452;
 
   INVALID_OPERATOR_NAME = 10500;
+
+  // KYC / contact rebind guards. Returned when a user tries to re-run the
+  // verify flow on a contact (email / mobile) that is already verified,
+  // which would otherwise silently overwrite the previously bound value.
+  EMAIL_ALREADY_VERIFIED = 10501 [(errors.code) = 409];
+  PHONE_ALREADY_VERIFIED = 10502 [(errors.code) = 409];
 }

--- a/user/service/v1/error_reason_errors.pb.go
+++ b/user/service/v1/error_reason_errors.pb.go
@@ -2184,3 +2184,33 @@ func IsInvalidOperatorName(err error) bool {
 func ErrorInvalidOperatorName(format string, args ...interface{}) *errors.Error {
 	return errors.New(500, ErrorReason_INVALID_OPERATOR_NAME.String(), fmt.Sprintf(format, args...))
 }
+
+// KYC / contact rebind guards. Returned when a user tries to re-run the
+// verify flow on a contact (email / mobile) that is already verified,
+// which would otherwise silently overwrite the previously bound value.
+func IsEmailAlreadyVerified(err error) bool {
+	if err == nil {
+		return false
+	}
+	e := errors.FromError(err)
+	return e.Reason == ErrorReason_EMAIL_ALREADY_VERIFIED.String() && e.Code == 409
+}
+
+// KYC / contact rebind guards. Returned when a user tries to re-run the
+// verify flow on a contact (email / mobile) that is already verified,
+// which would otherwise silently overwrite the previously bound value.
+func ErrorEmailAlreadyVerified(format string, args ...interface{}) *errors.Error {
+	return errors.New(409, ErrorReason_EMAIL_ALREADY_VERIFIED.String(), fmt.Sprintf(format, args...))
+}
+
+func IsPhoneAlreadyVerified(err error) bool {
+	if err == nil {
+		return false
+	}
+	e := errors.FromError(err)
+	return e.Reason == ErrorReason_PHONE_ALREADY_VERIFIED.String() && e.Code == 409
+}
+
+func ErrorPhoneAlreadyVerified(format string, args ...interface{}) *errors.Error {
+	return errors.New(409, ErrorReason_PHONE_ALREADY_VERIFIED.String(), fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
## Summary
- Adds `EMAIL_ALREADY_VERIFIED` (10501) and `PHONE_ALREADY_VERIFIED` (10502) under `api.user.service.v1.ErrorReason`, both returning HTTP 409.
- Regenerates `error_reason.pb.go` and `error_reason_errors.pb.go`.

## Why
meepo-user-service currently reuses `EMAIL_ALREADY_EXISTS` / `PHONE_ALREADY_EXISTS` for two different situations:
- contact is owned by another user (original intent), vs
- the current user has already verified it (new guard landing in user-service)

The two cases call for different client handling ("pick another email" vs "you already verified this, nothing to do"). Dedicated codes make that distinction explicit.

## Test plan
- [x] `make api` regenerates cleanly with only the three expected files changed
- [ ] Downstream meepo-user-service PR consumes the new errors via `go get @<hash>` after this merges