### PR TITLE
docs(crm): document Telegram asset type and channel

### DIFF
--- a/crm/service/v1/asset.pb.go
+++ b/crm/service/v1/asset.pb.go
@@ -24,15 +24,33 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Asset types
+// Asset types.
+// Each type maps to a CRM workflow action (see AssetService doc) and
+// determines which fields of AssetVersion are used at render time.
 type AssetType int32
 
 const (
 	AssetType_ASSET_TYPE_UNSPECIFIED AssetType = 0
-	AssetType_ASSET_TYPE_EMAIL       AssetType = 1
-	AssetType_ASSET_TYPE_SMS         AssetType = 2
-	AssetType_ASSET_TYPE_PUSH        AssetType = 3
-	AssetType_ASSET_TYPE_INBOX       AssetType = 4
+	// Email: `subject` is email subject, `content` is HTML body,
+	// `preview_text` is preheader. Consumed by `send_email` action.
+	AssetType_ASSET_TYPE_EMAIL AssetType = 1
+	// SMS: `content` is plain-text body. `subject` and `preview_text`
+	// are ignored. Consumed by `send_sms` action.
+	AssetType_ASSET_TYPE_SMS AssetType = 2
+	// Push: `subject` is notification title, `content` is body,
+	// `preview_text` is subtitle. Consumed by `send_push` action.
+	AssetType_ASSET_TYPE_PUSH AssetType = 3
+	// Inbox: in-app inbox message. `subject` is title, `content` is body.
+	// Consumed by `send_inbox` action.
+	AssetType_ASSET_TYPE_INBOX AssetType = 4
+	// Telegram: `content` is the HTML caption/text of the Telegram
+	// message (supports HTML formatting via Telegram Bot API).
+	// `subject` and `preview_text` are not used.
+	// message_type (text/photo/video/animation), media_url, and inline
+	// keyboard buttons (url / web_app_url) are supplied by the
+	// `send_telegram` workflow action config, not by the asset — the
+	// same asset can thus be reused with different media and CTAs.
+	AssetType_ASSET_TYPE_TELEGRAM AssetType = 5
 )
 
 // Enum value maps for AssetType.
@@ -43,6 +61,7 @@ var (
 		2: "ASSET_TYPE_SMS",
 		3: "ASSET_TYPE_PUSH",
 		4: "ASSET_TYPE_INBOX",
+		5: "ASSET_TYPE_TELEGRAM",
 	}
 	AssetType_value = map[string]int32{
 		"ASSET_TYPE_UNSPECIFIED": 0,
@@ -50,6 +69,7 @@ var (
 		"ASSET_TYPE_SMS":         2,
 		"ASSET_TYPE_PUSH":        3,
 		"ASSET_TYPE_INBOX":       4,
+		"ASSET_TYPE_TELEGRAM":    5,
 	}
 )
 
@@ -2642,13 +2662,14 @@ const file_crm_service_v1_asset_proto_rawDesc = "" +
 	"\x14unresolved_variables\x18\a \x03(\tR\x13unresolvedVariables\x1aD\n" +
 	"\x16ResolvedVariablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*|\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\x95\x01\n" +
 	"\tAssetType\x12\x1a\n" +
 	"\x16ASSET_TYPE_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10ASSET_TYPE_EMAIL\x10\x01\x12\x12\n" +
 	"\x0eASSET_TYPE_SMS\x10\x02\x12\x13\n" +
 	"\x0fASSET_TYPE_PUSH\x10\x03\x12\x14\n" +
-	"\x10ASSET_TYPE_INBOX\x10\x04*w\n" +
+	"\x10ASSET_TYPE_INBOX\x10\x04\x12\x17\n" +
+	"\x13ASSET_TYPE_TELEGRAM\x10\x05*w\n" +
 	"\vAssetStatus\x12\x1c\n" +
 	"\x18ASSET_STATUS_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12ASSET_STATUS_DRAFT\x10\x01\x12\x17\n" +

--- a/crm/service/v1/asset.proto
+++ b/crm/service/v1/asset.proto
@@ -12,7 +12,20 @@ option java_multiple_files = true;
 option java_package = "api.crm.service.v1";
 
 // AssetService provides operations for managing marketing campaign templates
-// (Email, SMS, Push, Inbox) with multi-language support and variable rendering.
+// with multi-language support and variable rendering.
+//
+// Supported channels (see AssetType):
+//   - Email  — rendered by CRM `send_email` workflow action
+//   - SMS    — rendered by CRM `send_sms` workflow action
+//   - Push   — rendered by CRM `send_push` workflow action
+//   - Telegram — rendered by CRM `send_telegram` workflow action;
+//                delivered via push-service TelegramBot/SendTelegramToUser.
+//                Asset content is the HTML caption/text of the Telegram
+//                message; media_url and inline keyboard buttons are
+//                configured on the workflow action (not on the asset),
+//                so the same asset can be reused with different media
+//                and CTAs per campaign.
+//   - Inbox  — in-app inbox message
 service AssetService {
     // Asset CRUD operations
     rpc CreateAsset(CreateAssetRequest) returns (CreateAssetResponse);
@@ -37,13 +50,31 @@ service AssetService {
     rpc RenderAsset(RenderAssetRequest) returns (RenderAssetResponse);
 }
 
-// Asset types
+// Asset types.
+// Each type maps to a CRM workflow action (see AssetService doc) and
+// determines which fields of AssetVersion are used at render time.
 enum AssetType {
     ASSET_TYPE_UNSPECIFIED = 0;
+    // Email: `subject` is email subject, `content` is HTML body,
+    // `preview_text` is preheader. Consumed by `send_email` action.
     ASSET_TYPE_EMAIL = 1;
+    // SMS: `content` is plain-text body. `subject` and `preview_text`
+    // are ignored. Consumed by `send_sms` action.
     ASSET_TYPE_SMS = 2;
+    // Push: `subject` is notification title, `content` is body,
+    // `preview_text` is subtitle. Consumed by `send_push` action.
     ASSET_TYPE_PUSH = 3;
+    // Inbox: in-app inbox message. `subject` is title, `content` is body.
+    // Consumed by `send_inbox` action.
     ASSET_TYPE_INBOX = 4;
+    // Telegram: `content` is the HTML caption/text of the Telegram
+    // message (supports HTML formatting via Telegram Bot API).
+    // `subject` and `preview_text` are not used.
+    // message_type (text/photo/video/animation), media_url, and inline
+    // keyboard buttons (url / web_app_url) are supplied by the
+    // `send_telegram` workflow action config, not by the asset — the
+    // same asset can thus be reused with different media and CTAs.
+    ASSET_TYPE_TELEGRAM = 5;
 }
 
 // Asset status lifecycle

--- a/crm/service/v1/asset_grpc.pb.go
+++ b/crm/service/v1/asset_grpc.pb.go
@@ -40,7 +40,20 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
 // AssetService provides operations for managing marketing campaign templates
-// (Email, SMS, Push, Inbox) with multi-language support and variable rendering.
+// with multi-language support and variable rendering.
+//
+// Supported channels (see AssetType):
+//   - Email  — rendered by CRM `send_email` workflow action
+//   - SMS    — rendered by CRM `send_sms` workflow action
+//   - Push   — rendered by CRM `send_push` workflow action
+//   - Telegram — rendered by CRM `send_telegram` workflow action;
+//     delivered via push-service TelegramBot/SendTelegramToUser.
+//     Asset content is the HTML caption/text of the Telegram
+//     message; media_url and inline keyboard buttons are
+//     configured on the workflow action (not on the asset),
+//     so the same asset can be reused with different media
+//     and CTAs per campaign.
+//   - Inbox  — in-app inbox message
 type AssetServiceClient interface {
 	// Asset CRUD operations
 	CreateAsset(ctx context.Context, in *CreateAssetRequest, opts ...grpc.CallOption) (*CreateAssetResponse, error)
@@ -215,7 +228,20 @@ func (c *assetServiceClient) RenderAsset(ctx context.Context, in *RenderAssetReq
 // for forward compatibility.
 //
 // AssetService provides operations for managing marketing campaign templates
-// (Email, SMS, Push, Inbox) with multi-language support and variable rendering.
+// with multi-language support and variable rendering.
+//
+// Supported channels (see AssetType):
+//   - Email  — rendered by CRM `send_email` workflow action
+//   - SMS    — rendered by CRM `send_sms` workflow action
+//   - Push   — rendered by CRM `send_push` workflow action
+//   - Telegram — rendered by CRM `send_telegram` workflow action;
+//     delivered via push-service TelegramBot/SendTelegramToUser.
+//     Asset content is the HTML caption/text of the Telegram
+//     message; media_url and inline keyboard buttons are
+//     configured on the workflow action (not on the asset),
+//     so the same asset can be reused with different media
+//     and CTAs per campaign.
+//   - Inbox  — in-app inbox message
 type AssetServiceServer interface {
 	// Asset CRUD operations
 	CreateAsset(context.Context, *CreateAssetRequest) (*CreateAssetResponse, error)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15641,6 +15641,7 @@ components:
                         - ASSET_TYPE_SMS
                         - ASSET_TYPE_PUSH
                         - ASSET_TYPE_INBOX
+                        - ASSET_TYPE_TELEGRAM
                     type: string
                     description: 'Delivery channel: `ASSET_TYPE_EMAIL`, `ASSET_TYPE_SMS`, `ASSET_TYPE_PUSH`, `ASSET_TYPE_INBOX`'
                     format: enum
@@ -19630,6 +19631,7 @@ components:
                         - ASSET_TYPE_SMS
                         - ASSET_TYPE_PUSH
                         - ASSET_TYPE_INBOX
+                        - ASSET_TYPE_TELEGRAM
                     type: string
                     description: Filter by asset type (optional)
                     format: enum
@@ -19669,6 +19671,7 @@ components:
                         - ASSET_TYPE_SMS
                         - ASSET_TYPE_PUSH
                         - ASSET_TYPE_INBOX
+                        - ASSET_TYPE_TELEGRAM
                     type: string
                     description: Filter by asset type (optional)
                     format: enum
@@ -26611,6 +26614,7 @@ components:
                         - ASSET_TYPE_SMS
                         - ASSET_TYPE_PUSH
                         - ASSET_TYPE_INBOX
+                        - ASSET_TYPE_TELEGRAM
                     type: string
                     format: enum
                 status:


### PR DESCRIPTION
## Summary

The crm-service already supports a \`telegram\` asset type (rendered by the \`send_telegram\` workflow action and delivered via push-service \`TelegramBot/SendTelegramToUser\`), but the proto contract did not reflect this — \`AssetType\` enum was missing the Telegram value and the \`AssetService\` doc only listed Email / SMS / Push / Inbox.

This PR adds the missing type and clarifies channel semantics so UI / integrators / MCP tools have an accurate contract.

## Changes
- \`AssetType\` enum: add \`ASSET_TYPE_TELEGRAM = 5\`
- \`AssetType\` enum: annotate each value with which AssetVersion fields it uses (\`subject\` vs \`content\` vs \`preview_text\`)
- \`AssetService\` service doc: list all supported channels, incl. Telegram note that \`media_url\` / inline keyboard buttons live on the workflow action config (not on the asset) so the same template can be reused with different media / CTAs per campaign

## Runtime impact
None. \`crm-service/internal/data/asset_models.go\` already defines \`AssetTypeTelegram = "telegram"\` and \`ActionTypeSendTelegram = "send_telegram"\`. This PR only surfaces those in the proto layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)