### PR TITLE
fix(backoffice): make UpdateBetTickerConfigRequest.enable optional

### DIFF
--- a/backoffice/service/v1/backoffice_game.pb.go
+++ b/backoffice/service/v1/backoffice_game.pb.go
@@ -4660,11 +4660,15 @@ func (x *BackofficeListGamesUnderTagResponse) GetPageSize() int32 {
 }
 
 type UpdateBetTickerConfigRequest struct {
-	state                 protoimpl.MessageState               `protogen:"open.v1"`
-	List                  []*UpdateBetTickerConfigRequest_Item `protobuf:"bytes,1,rep,name=list,proto3" json:"list,omitempty"`
-	Enable                bool                                 `protobuf:"varint,2,opt,name=enable,proto3" json:"enable,omitempty"`
-	TargetOperatorContext *common.OperatorContext              `protobuf:"bytes,3,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
-	GlobalTickerEnabled   *bool                                `protobuf:"varint,4,opt,name=global_ticker_enabled,json=globalTickerEnabled,proto3,oneof" json:"global_ticker_enabled,omitempty"`
+	state protoimpl.MessageState               `protogen:"open.v1"`
+	List  []*UpdateBetTickerConfigRequest_Item `protobuf:"bytes,1,rep,name=list,proto3" json:"list,omitempty"`
+	// enable is optional; when omitted the server preserves the existing
+	// per-country value (or defaults to true for new rows). Prevents the
+	// proto3 zero-value from silently disabling the ticker when a caller
+	// only wants to update other fields (e.g. global_ticker_enabled).
+	Enable                *bool                   `protobuf:"varint,2,opt,name=enable,proto3,oneof" json:"enable,omitempty"`
+	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,3,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
+	GlobalTickerEnabled   *bool                   `protobuf:"varint,4,opt,name=global_ticker_enabled,json=globalTickerEnabled,proto3,oneof" json:"global_ticker_enabled,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -4707,8 +4711,8 @@ func (x *UpdateBetTickerConfigRequest) GetList() []*UpdateBetTickerConfigRequest
 }
 
 func (x *UpdateBetTickerConfigRequest) GetEnable() bool {
-	if x != nil {
-		return x.Enable
+	if x != nil && x.Enable != nil {
+		return *x.Enable
 	}
 	return false
 }
@@ -6504,12 +6508,12 @@ const file_backoffice_service_v1_backoffice_game_proto_rawDesc = "" +
 	"orderIndex\x12\x16\n" +
 	"\x06sticky\x18\f \x01(\bR\x06sticky\x12\x1b\n" +
 	"\tfree_spin\x18\r \x01(\bR\bfreeSpin\x12\x10\n" +
-	"\x03rtp\x18\x0e \x01(\tR\x03rtp\"\x81\x04\n" +
+	"\x03rtp\x18\x0e \x01(\tR\x03rtp\"\x91\x04\n" +
 	"\x1cUpdateBetTickerConfigRequest\x12P\n" +
-	"\x04list\x18\x01 \x03(\v2<.api.backoffice.service.v1.UpdateBetTickerConfigRequest.ItemR\x04list\x12\x16\n" +
-	"\x06enable\x18\x02 \x01(\bR\x06enable\x12S\n" +
+	"\x04list\x18\x01 \x03(\v2<.api.backoffice.service.v1.UpdateBetTickerConfigRequest.ItemR\x04list\x12\x1b\n" +
+	"\x06enable\x18\x02 \x01(\bH\x00R\x06enable\x88\x01\x01\x12S\n" +
 	"\x17target_operator_context\x18\x03 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x127\n" +
-	"\x15global_ticker_enabled\x18\x04 \x01(\bH\x00R\x13globalTickerEnabled\x88\x01\x01\x1a\xce\x01\n" +
+	"\x15global_ticker_enabled\x18\x04 \x01(\bH\x01R\x13globalTickerEnabled\x88\x01\x01\x1a\xce\x01\n" +
 	"\x04Item\x12\x18\n" +
 	"\acountry\x18\x01 \x01(\tR\acountry\x12F\n" +
 	"\aall_bet\x18\x02 \x01(\v2(.api.push.service.v1.BettingFilterConfigH\x00R\x06allBet\x88\x01\x01\x12J\n" +
@@ -6517,7 +6521,8 @@ const file_backoffice_service_v1_backoffice_game_proto_rawDesc = "" +
 	"\n" +
 	"\b_all_betB\f\n" +
 	"\n" +
-	"_high_winsB\x18\n" +
+	"_high_winsB\t\n" +
+	"\a_enableB\x18\n" +
 	"\x16_global_ticker_enabled\"q\n" +
 	"\x1aListBetTickerConfigRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext2\xa0Q\n" +

--- a/backoffice/service/v1/backoffice_game.pb.go
+++ b/backoffice/service/v1/backoffice_game.pb.go
@@ -4662,10 +4662,13 @@ func (x *BackofficeListGamesUnderTagResponse) GetPageSize() int32 {
 type UpdateBetTickerConfigRequest struct {
 	state protoimpl.MessageState               `protogen:"open.v1"`
 	List  []*UpdateBetTickerConfigRequest_Item `protobuf:"bytes,1,rep,name=list,proto3" json:"list,omitempty"`
-	// enable is optional; when omitted the server preserves the existing
-	// per-country value (or defaults to true for new rows). Prevents the
-	// proto3 zero-value from silently disabling the ticker when a caller
-	// only wants to update other fields (e.g. global_ticker_enabled).
+	// enable is optional. Server-side semantics:
+	//   - omitted: preserve the existing value for the (operator, country)
+	//     row, or default to true when no such row exists yet.
+	//   - explicit true/false: written to the DB as-is.
+	//
+	// This avoids the proto3 zero-value silently disabling the ticker when a
+	// caller only wants to update other fields (e.g. global_ticker_enabled).
 	Enable                *bool                   `protobuf:"varint,2,opt,name=enable,proto3,oneof" json:"enable,omitempty"`
 	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,3,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
 	GlobalTickerEnabled   *bool                   `protobuf:"varint,4,opt,name=global_ticker_enabled,json=globalTickerEnabled,proto3,oneof" json:"global_ticker_enabled,omitempty"`

--- a/backoffice/service/v1/backoffice_game.pb.validate.go
+++ b/backoffice/service/v1/backoffice_game.pb.validate.go
@@ -9078,8 +9078,6 @@ func (m *UpdateBetTickerConfigRequest) validate(all bool) error {
 
 	}
 
-	// no validation rules for Enable
-
 	if all {
 		switch v := interface{}(m.GetTargetOperatorContext()).(type) {
 		case interface{ ValidateAll() error }:
@@ -9107,6 +9105,10 @@ func (m *UpdateBetTickerConfigRequest) validate(all bool) error {
 				cause:  err,
 			}
 		}
+	}
+
+	if m.Enable != nil {
+		// no validation rules for Enable
 	}
 
 	if m.GlobalTickerEnabled != nil {

--- a/backoffice/service/v1/backoffice_game.proto
+++ b/backoffice/service/v1/backoffice_game.proto
@@ -1014,10 +1014,12 @@ message UpdateBetTickerConfigRequest {
 		optional api.push.service.v1.BettingFilterConfig high_wins = 3;
 	}
 	repeated Item list = 1;
-	// enable is optional; when omitted the server preserves the existing
-	// per-country value (or defaults to true for new rows). Prevents the
-	// proto3 zero-value from silently disabling the ticker when a caller
-	// only wants to update other fields (e.g. global_ticker_enabled).
+	// enable is optional. Server-side semantics:
+	//   - omitted: preserve the existing value for the (operator, country)
+	//     row, or default to true when no such row exists yet.
+	//   - explicit true/false: written to the DB as-is.
+	// This avoids the proto3 zero-value silently disabling the ticker when a
+	// caller only wants to update other fields (e.g. global_ticker_enabled).
 	optional bool enable = 2;
 	api.common.OperatorContext target_operator_context = 3;
 	optional bool global_ticker_enabled = 4;

--- a/backoffice/service/v1/backoffice_game.proto
+++ b/backoffice/service/v1/backoffice_game.proto
@@ -1014,7 +1014,11 @@ message UpdateBetTickerConfigRequest {
 		optional api.push.service.v1.BettingFilterConfig high_wins = 3;
 	}
 	repeated Item list = 1;
-	bool enable = 2;
+	// enable is optional; when omitted the server preserves the existing
+	// per-country value (or defaults to true for new rows). Prevents the
+	// proto3 zero-value from silently disabling the ticker when a caller
+	// only wants to update other fields (e.g. global_ticker_enabled).
+	optional bool enable = 2;
 	api.common.OperatorContext target_operator_context = 3;
 	optional bool global_ticker_enabled = 4;
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25052,10 +25052,12 @@ components:
                 enable:
                     type: boolean
                     description: |-
-                        enable is optional; when omitted the server preserves the existing
-                         per-country value (or defaults to true for new rows). Prevents the
-                         proto3 zero-value from silently disabling the ticker when a caller
-                         only wants to update other fields (e.g. global_ticker_enabled).
+                        enable is optional. Server-side semantics:
+                           - omitted: preserve the existing value for the (operator, country)
+                             row, or default to true when no such row exists yet.
+                           - explicit true/false: written to the DB as-is.
+                         This avoids the proto3 zero-value silently disabling the ticker when a
+                         caller only wants to update other fields (e.g. global_ticker_enabled).
                 targetOperatorContext:
                     $ref: '#/components/schemas/api.common.OperatorContext'
                 globalTickerEnabled:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25051,6 +25051,11 @@ components:
                         $ref: '#/components/schemas/api.backoffice.service.v1.UpdateBetTickerConfigRequest_Item'
                 enable:
                     type: boolean
+                    description: |-
+                        enable is optional; when omitted the server preserves the existing
+                         per-country value (or defaults to true for new rows). Prevents the
+                         proto3 zero-value from silently disabling the ticker when a caller
+                         only wants to update other fields (e.g. global_ticker_enabled).
                 targetOperatorContext:
                     $ref: '#/components/schemas/api.common.OperatorContext'
                 globalTickerEnabled:

--- a/push/service/v1/push.pb.go
+++ b/push/service/v1/push.pb.go
@@ -616,11 +616,15 @@ func (x *BettingFilterConfig) GetMaskingRule() string {
 }
 
 type UpdateBetTickerConfigRequest struct {
-	state               protoimpl.MessageState               `protogen:"open.v1"`
-	List                []*UpdateBetTickerConfigRequest_Item `protobuf:"bytes,1,rep,name=list,proto3" json:"list,omitempty"`
-	Enable              bool                                 `protobuf:"varint,2,opt,name=enable,proto3" json:"enable,omitempty"`
-	OperatorId          int64                                `protobuf:"varint,3,opt,name=operator_id,json=operatorId,proto3" json:"operator_id,omitempty"`
-	GlobalTickerEnabled *bool                                `protobuf:"varint,4,opt,name=global_ticker_enabled,json=globalTickerEnabled,proto3,oneof" json:"global_ticker_enabled,omitempty"`
+	state protoimpl.MessageState               `protogen:"open.v1"`
+	List  []*UpdateBetTickerConfigRequest_Item `protobuf:"bytes,1,rep,name=list,proto3" json:"list,omitempty"`
+	// enable is optional; when omitted the server preserves the existing
+	// per-country value (or defaults to true for new rows). Prevents the
+	// proto3 zero-value from silently disabling the ticker when a caller
+	// only wants to update other fields (e.g. global_ticker_enabled).
+	Enable              *bool `protobuf:"varint,2,opt,name=enable,proto3,oneof" json:"enable,omitempty"`
+	OperatorId          int64 `protobuf:"varint,3,opt,name=operator_id,json=operatorId,proto3" json:"operator_id,omitempty"`
+	GlobalTickerEnabled *bool `protobuf:"varint,4,opt,name=global_ticker_enabled,json=globalTickerEnabled,proto3,oneof" json:"global_ticker_enabled,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -663,8 +667,8 @@ func (x *UpdateBetTickerConfigRequest) GetList() []*UpdateBetTickerConfigRequest
 }
 
 func (x *UpdateBetTickerConfigRequest) GetEnable() bool {
-	if x != nil {
-		return x.Enable
+	if x != nil && x.Enable != nil {
+		return *x.Enable
 	}
 	return false
 }
@@ -1577,13 +1581,13 @@ const file_push_service_v1_push_proto_rawDesc = "" +
 	"\x0fmasking_enabled\x18\x05 \x01(\bH\x00R\x0emaskingEnabled\x88\x01\x01\x12&\n" +
 	"\fmasking_rule\x18\x06 \x01(\tH\x01R\vmaskingRule\x88\x01\x01B\x12\n" +
 	"\x10_masking_enabledB\x0f\n" +
-	"\r_masking_rule\"\xc7\x03\n" +
+	"\r_masking_rule\"\xd7\x03\n" +
 	"\x1cUpdateBetTickerConfigRequest\x12J\n" +
-	"\x04list\x18\x01 \x03(\v26.api.push.service.v1.UpdateBetTickerConfigRequest.ItemR\x04list\x12\x16\n" +
-	"\x06enable\x18\x02 \x01(\bR\x06enable\x12\x1f\n" +
+	"\x04list\x18\x01 \x03(\v26.api.push.service.v1.UpdateBetTickerConfigRequest.ItemR\x04list\x12\x1b\n" +
+	"\x06enable\x18\x02 \x01(\bH\x00R\x06enable\x88\x01\x01\x12\x1f\n" +
 	"\voperator_id\x18\x03 \x01(\x03R\n" +
 	"operatorId\x127\n" +
-	"\x15global_ticker_enabled\x18\x04 \x01(\bH\x00R\x13globalTickerEnabled\x88\x01\x01\x1a\xce\x01\n" +
+	"\x15global_ticker_enabled\x18\x04 \x01(\bH\x01R\x13globalTickerEnabled\x88\x01\x01\x1a\xce\x01\n" +
 	"\x04Item\x12\x18\n" +
 	"\acountry\x18\x01 \x01(\tR\acountry\x12F\n" +
 	"\aall_bet\x18\x02 \x01(\v2(.api.push.service.v1.BettingFilterConfigH\x00R\x06allBet\x88\x01\x01\x12J\n" +
@@ -1591,7 +1595,8 @@ const file_push_service_v1_push_proto_rawDesc = "" +
 	"\n" +
 	"\b_all_betB\f\n" +
 	"\n" +
-	"_high_winsB\x18\n" +
+	"_high_winsB\t\n" +
+	"\a_enableB\x18\n" +
 	"\x16_global_ticker_enabled\"\x1f\n" +
 	"\x1dUpdateBetTickerConfigResponse\"=\n" +
 	"\x1aListBetTickerConfigRequest\x12\x1f\n" +

--- a/push/service/v1/push.pb.go
+++ b/push/service/v1/push.pb.go
@@ -618,10 +618,13 @@ func (x *BettingFilterConfig) GetMaskingRule() string {
 type UpdateBetTickerConfigRequest struct {
 	state protoimpl.MessageState               `protogen:"open.v1"`
 	List  []*UpdateBetTickerConfigRequest_Item `protobuf:"bytes,1,rep,name=list,proto3" json:"list,omitempty"`
-	// enable is optional; when omitted the server preserves the existing
-	// per-country value (or defaults to true for new rows). Prevents the
-	// proto3 zero-value from silently disabling the ticker when a caller
-	// only wants to update other fields (e.g. global_ticker_enabled).
+	// enable is optional. Server-side semantics:
+	//   - omitted: preserve the existing value for the (operator, country)
+	//     row, or default to true when no such row exists yet.
+	//   - explicit true/false: written to the DB as-is.
+	//
+	// This avoids the proto3 zero-value silently disabling the ticker when a
+	// caller only wants to update other fields (e.g. global_ticker_enabled).
 	Enable              *bool `protobuf:"varint,2,opt,name=enable,proto3,oneof" json:"enable,omitempty"`
 	OperatorId          int64 `protobuf:"varint,3,opt,name=operator_id,json=operatorId,proto3" json:"operator_id,omitempty"`
 	GlobalTickerEnabled *bool `protobuf:"varint,4,opt,name=global_ticker_enabled,json=globalTickerEnabled,proto3,oneof" json:"global_ticker_enabled,omitempty"`

--- a/push/service/v1/push.pb.validate.go
+++ b/push/service/v1/push.pb.validate.go
@@ -1210,9 +1210,11 @@ func (m *UpdateBetTickerConfigRequest) validate(all bool) error {
 
 	}
 
-	// no validation rules for Enable
-
 	// no validation rules for OperatorId
+
+	if m.Enable != nil {
+		// no validation rules for Enable
+	}
 
 	if m.GlobalTickerEnabled != nil {
 		// no validation rules for GlobalTickerEnabled

--- a/push/service/v1/push.proto
+++ b/push/service/v1/push.proto
@@ -122,10 +122,12 @@ message UpdateBetTickerConfigRequest {
 		optional BettingFilterConfig high_wins = 3;
 	}
 	repeated Item list = 1;
-	// enable is optional; when omitted the server preserves the existing
-	// per-country value (or defaults to true for new rows). Prevents the
-	// proto3 zero-value from silently disabling the ticker when a caller
-	// only wants to update other fields (e.g. global_ticker_enabled).
+	// enable is optional. Server-side semantics:
+	//   - omitted: preserve the existing value for the (operator, country)
+	//     row, or default to true when no such row exists yet.
+	//   - explicit true/false: written to the DB as-is.
+	// This avoids the proto3 zero-value silently disabling the ticker when a
+	// caller only wants to update other fields (e.g. global_ticker_enabled).
 	optional bool enable = 2;
 	int64 operator_id = 3;
 	optional bool global_ticker_enabled = 4;

--- a/push/service/v1/push.proto
+++ b/push/service/v1/push.proto
@@ -122,7 +122,11 @@ message UpdateBetTickerConfigRequest {
 		optional BettingFilterConfig high_wins = 3;
 	}
 	repeated Item list = 1;
-	bool enable = 2;
+	// enable is optional; when omitted the server preserves the existing
+	// per-country value (or defaults to true for new rows). Prevents the
+	// proto3 zero-value from silently disabling the ticker when a caller
+	// only wants to update other fields (e.g. global_ticker_enabled).
+	optional bool enable = 2;
 	int64 operator_id = 3;
 	optional bool global_ticker_enabled = 4;
 }


### PR DESCRIPTION
## Summary
- \`UpdateBetTickerConfigRequest.enable\` 改为 \`optional bool\`，让服务端能区分"未设置"和"显式 false"
- 配合 \`meepo-push-service\` 的 fetch-before-write，避免前端不传 \`enable\` 时把 DB 置为 false

## Background
BetQ 等站点开启 global share 后 bet ticker 无数据：
1. 前端 payload 从不携带顶层 \`enable\`
2. proto3 \`bool\` 默认 false 被 \`SaveConfig\` 全量写入 DB
3. \`processor.go:127\` 的 \`if !config.Enable { return nil }\` 丢弃所有 bet event → buffer 枯竭（72h TTL）

已有 push-service hotfix（\`Enable: true\` 硬编码）部署到 prod（[push-service PR #129](https://github.com/infigaming-com/meepo-push-service/pull/129)），本 PR 是 main 分支的完整修复前置。

## Test plan
- [ ] \`make api\` 重新生成无差异
- [ ] push-service 升级 meepo-api 版本后能正确 nil-check \`Enable\`
- [ ] 前端不传 \`enable\` 字段时，DB 保留原值
- [ ] 合并后打 tag 并通知 push-service 升级