### PR TITLE
chore(wallet): mark GetWalletConfig as deprecated

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11282,7 +11282,12 @@ paths:
         post:
             tags:
                 - Wallet
-            description: GetWalletConfig returns the wallet configuration for the current operator (user-facing)
+            description: |-
+                GetWalletConfig returns the wallet configuration for the current operator (user-facing)
+
+                 Deprecated: use GetGamificationConfig instead — its response is a strict superset
+                 (includes clear_bonus_on_withdrawal) and is backed by the operator-level bundle cache,
+                 so switching also fixes a server-side cache miss on every call to this endpoint.
             operationId: Wallet_GetWalletConfig
             requestBody:
                 content:

--- a/wallet/service/v1/wallet.pb.go
+++ b/wallet/service/v1/wallet.pb.go
@@ -20770,7 +20770,7 @@ const file_wallet_service_v1_wallet_proto_rawDesc = "" +
 	"\x1dWITHDRAW_SCENARIO_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18WITHDRAW_SCENARIO_PLAYER\x10\x01\x12\x1f\n" +
 	"\x1bWITHDRAW_SCENARIO_AFFILIATE\x10\x02\x12\x1e\n" +
-	"\x1aWITHDRAW_SCENARIO_OPERATOR\x10\x032\xb6i\n" +
+	"\x1aWITHDRAW_SCENARIO_OPERATOR\x10\x032\xb9i\n" +
 	"\x06Wallet\x12\x95\x01\n" +
 	"\x0fGetUserBalances\x12-.api.wallet.service.v1.GetUserBalancesRequest\x1a..api.wallet.service.v1.GetUserBalancesResponse\"#\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v1/wallet/balances/list\x12o\n" +
 	"\x0eGetUserBalance\x12,.api.wallet.service.v1.GetUserBalanceRequest\x1a-.api.wallet.service.v1.GetUserBalanceResponse\"\x00\x12\xa9\x01\n" +
@@ -20858,8 +20858,8 @@ const file_wallet_service_v1_wallet_proto_rawDesc = "" +
 	"\x1eGetUserGameTransactionsSummary\x12<.api.wallet.service.v1.GetUserGameTransactionsSummaryRequest\x1a=.api.wallet.service.v1.GetUserGameTransactionsSummaryResponse\"\x00\x12x\n" +
 	"\x11CreditFreespinWin\x12/.api.wallet.service.v1.CreditFreespinWinRequest\x1a0.api.wallet.service.v1.CreditFreespinWinResponse\"\x00\x12u\n" +
 	"\x10CreditFreeBetWin\x12..api.wallet.service.v1.CreditFreeBetWinRequest\x1a/.api.wallet.service.v1.CreditFreeBetWinResponse\"\x00\x12\xa2\x01\n" +
-	"\x1fGetOperatorUserFinancialSummary\x12=.api.wallet.service.v1.GetOperatorUserFinancialSummaryRequest\x1a>.api.wallet.service.v1.GetOperatorUserFinancialSummaryResponse\"\x00\x12\x92\x01\n" +
-	"\x0fGetWalletConfig\x12-.api.wallet.service.v1.GetWalletConfigRequest\x1a..api.wallet.service.v1.GetWalletConfigResponse\" \x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/v1/wallet/config/get\x12\xb1\x01\n" +
+	"\x1fGetOperatorUserFinancialSummary\x12=.api.wallet.service.v1.GetOperatorUserFinancialSummaryRequest\x1a>.api.wallet.service.v1.GetOperatorUserFinancialSummaryResponse\"\x00\x12\x95\x01\n" +
+	"\x0fGetWalletConfig\x12-.api.wallet.service.v1.GetWalletConfigRequest\x1a..api.wallet.service.v1.GetWalletConfigResponse\"#\x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/v1/wallet/config/get\x88\x02\x01\x12\xb1\x01\n" +
 	"\x15GetGamificationConfig\x123.api.wallet.service.v1.GetGamificationConfigRequest\x1a4.api.wallet.service.v1.GetGamificationConfigResponse\"-\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/wallet/gamification/config/get\x12\x99\x01\n" +
 	"\x1cBatchGetUserFinancialMetrics\x12:.api.wallet.service.v1.BatchGetUserFinancialMetricsRequest\x1a;.api.wallet.service.v1.BatchGetUserFinancialMetricsResponse\"\x00\x12\xa2\x01\n" +
 	"\x1fManualAdjustCreditTurnoverField\x12=.api.wallet.service.v1.ManualAdjustCreditTurnoverFieldRequest\x1a>.api.wallet.service.v1.ManualAdjustCreditTurnoverFieldResponse\"\x00\x12~\n" +

--- a/wallet/service/v1/wallet.proto
+++ b/wallet/service/v1/wallet.proto
@@ -329,7 +329,12 @@ service Wallet {
 	rpc GetOperatorUserFinancialSummary(GetOperatorUserFinancialSummaryRequest) returns (GetOperatorUserFinancialSummaryResponse) {}
 
 	// GetWalletConfig returns the wallet configuration for the current operator (user-facing)
+	//
+	// Deprecated: use GetGamificationConfig instead — its response is a strict superset
+	// (includes clear_bonus_on_withdrawal) and is backed by the operator-level bundle cache,
+	// so switching also fixes a server-side cache miss on every call to this endpoint.
 	rpc GetWalletConfig(GetWalletConfigRequest) returns (GetWalletConfigResponse) {
+		option deprecated = true;
 		option (google.api.http) = {
 			post: "/v1/wallet/config/get"
 			body: "*"

--- a/wallet/service/v1/wallet_grpc.pb.go
+++ b/wallet/service/v1/wallet_grpc.pb.go
@@ -283,7 +283,12 @@ type WalletClient interface {
 	CreditFreeBetWin(ctx context.Context, in *CreditFreeBetWinRequest, opts ...grpc.CallOption) (*CreditFreeBetWinResponse, error)
 	// GetOperatorUserFinancialSummary returns the financial summary of all users by an operator
 	GetOperatorUserFinancialSummary(ctx context.Context, in *GetOperatorUserFinancialSummaryRequest, opts ...grpc.CallOption) (*GetOperatorUserFinancialSummaryResponse, error)
+	// Deprecated: Do not use.
 	// GetWalletConfig returns the wallet configuration for the current operator (user-facing)
+	//
+	// Deprecated: use GetGamificationConfig instead — its response is a strict superset
+	// (includes clear_bonus_on_withdrawal) and is backed by the operator-level bundle cache,
+	// so switching also fixes a server-side cache miss on every call to this endpoint.
 	GetWalletConfig(ctx context.Context, in *GetWalletConfigRequest, opts ...grpc.CallOption) (*GetWalletConfigResponse, error)
 	// GetGamificationConfig returns the per-currency gamification config (bet limits,
 	// bonus rules, wagering requirements) plus the operator-level clear-bonus-on-withdrawal flag.
@@ -1166,6 +1171,7 @@ func (c *walletClient) GetOperatorUserFinancialSummary(ctx context.Context, in *
 	return out, nil
 }
 
+// Deprecated: Do not use.
 func (c *walletClient) GetWalletConfig(ctx context.Context, in *GetWalletConfigRequest, opts ...grpc.CallOption) (*GetWalletConfigResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetWalletConfigResponse)
@@ -1424,7 +1430,12 @@ type WalletServer interface {
 	CreditFreeBetWin(context.Context, *CreditFreeBetWinRequest) (*CreditFreeBetWinResponse, error)
 	// GetOperatorUserFinancialSummary returns the financial summary of all users by an operator
 	GetOperatorUserFinancialSummary(context.Context, *GetOperatorUserFinancialSummaryRequest) (*GetOperatorUserFinancialSummaryResponse, error)
+	// Deprecated: Do not use.
 	// GetWalletConfig returns the wallet configuration for the current operator (user-facing)
+	//
+	// Deprecated: use GetGamificationConfig instead — its response is a strict superset
+	// (includes clear_bonus_on_withdrawal) and is backed by the operator-level bundle cache,
+	// so switching also fixes a server-side cache miss on every call to this endpoint.
 	GetWalletConfig(context.Context, *GetWalletConfigRequest) (*GetWalletConfigResponse, error)
 	// GetGamificationConfig returns the per-currency gamification config (bet limits,
 	// bonus rules, wagering requirements) plus the operator-level clear-bonus-on-withdrawal flag.

--- a/wallet/service/v1/wallet_http.pb.go
+++ b/wallet/service/v1/wallet_http.pb.go
@@ -67,6 +67,11 @@ type WalletHTTPServer interface {
 	// GetUserDepositRewardSequence GetUserDepositRewardSequence returns the current available deposit reward sequence of the user based on the user deposit stats
 	GetUserDepositRewardSequence(context.Context, *GetUserDepositRewardSequenceRequest) (*GetUserDepositRewardSequenceResponse, error)
 	// GetWalletConfig GetWalletConfig returns the wallet configuration for the current operator (user-facing)
+	//
+	// Deprecated: use GetGamificationConfig instead — its response is a strict superset
+	// (includes clear_bonus_on_withdrawal) and is backed by the operator-level bundle cache,
+	// so switching also fixes a server-side cache miss on every call to this endpoint.
+	// Deprecated: Do not use.
 	GetWalletConfig(context.Context, *GetWalletConfigRequest) (*GetWalletConfigResponse, error)
 	// ListResponsibleGamblingConfigs ListResponsibleGamblingConfigs lists gambling configs for a user with all currencies
 	ListResponsibleGamblingConfigs(context.Context, *ListResponsibleGamblingConfigsRequest) (*ListResponsibleGamblingConfigsResponse, error)
@@ -453,6 +458,11 @@ type WalletHTTPClient interface {
 	// GetUserDepositRewardSequence GetUserDepositRewardSequence returns the current available deposit reward sequence of the user based on the user deposit stats
 	GetUserDepositRewardSequence(ctx context.Context, req *GetUserDepositRewardSequenceRequest, opts ...http.CallOption) (rsp *GetUserDepositRewardSequenceResponse, err error)
 	// GetWalletConfig GetWalletConfig returns the wallet configuration for the current operator (user-facing)
+	//
+	// Deprecated: use GetGamificationConfig instead — its response is a strict superset
+	// (includes clear_bonus_on_withdrawal) and is backed by the operator-level bundle cache,
+	// so switching also fixes a server-side cache miss on every call to this endpoint.
+	// Deprecated: Do not use.
 	GetWalletConfig(ctx context.Context, req *GetWalletConfigRequest, opts ...http.CallOption) (rsp *GetWalletConfigResponse, err error)
 	// ListResponsibleGamblingConfigs ListResponsibleGamblingConfigs lists gambling configs for a user with all currencies
 	ListResponsibleGamblingConfigs(ctx context.Context, req *ListResponsibleGamblingConfigsRequest, opts ...http.CallOption) (rsp *ListResponsibleGamblingConfigsResponse, err error)
@@ -653,6 +663,11 @@ func (c *WalletHTTPClientImpl) GetUserDepositRewardSequence(ctx context.Context,
 }
 
 // GetWalletConfig GetWalletConfig returns the wallet configuration for the current operator (user-facing)
+//
+// Deprecated: use GetGamificationConfig instead — its response is a strict superset
+// (includes clear_bonus_on_withdrawal) and is backed by the operator-level bundle cache,
+// so switching also fixes a server-side cache miss on every call to this endpoint.
+// Deprecated: Do not use.
 func (c *WalletHTTPClientImpl) GetWalletConfig(ctx context.Context, in *GetWalletConfigRequest, opts ...http.CallOption) (*GetWalletConfigResponse, error) {
 	var out GetWalletConfigResponse
 	pattern := "/v1/wallet/config/get"


### PR DESCRIPTION
## Summary
- Marks `GetWalletConfig` (`POST /v1/wallet/config/get`) with `option deprecated = true;` plus a godoc comment pointing to `GetGamificationConfig` (the new bundle-cached endpoint added in #1296).
- `GetGamificationConfig` returns a strict superset — same `clear_bonus_on_withdrawal` bool, plus the per-currency list — so FE can consolidate onto a single call.
- Also removes a silent server-side inefficiency: the deprecated endpoint bypasses the operator config cache on every call, while `GetGamificationConfig` hits the bundle cache (one DB fetch per operator per 5 min TTL).

No handler removal in this PR — just the deprecation signal. The server RPC stays functional so existing callers keep working until FE switches.

## Test plan
- [ ] Protobuf generated stubs build against dependent services (no API surface break — `deprecated = true` is a tag, not a breaking change)
- [ ] FE confirms all `GetWalletConfig` callers can switch to `GetGamificationConfig` — tracked in follow-up
- [ ] Handler + `wallet_get_config.go` removal after FE migration — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)