### PR TITLE
feat(events): add BetErrorEvent for wallet bet error push

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -479,3 +479,28 @@ type SessionActivityEvent struct {
 	PrevClientSource   string   `json:"prevClientSource,omitempty"`
 	Timestamp          int64    `json:"timestamp"`
 }
+
+// BetErrorEvent is emitted by game-service when wallet rejects a bet with a
+// user-actionable reason (insufficient balance, per-bet limit exceeded) so that
+// push-service can forward it to the user's Centrifugo channel for a toast.
+//
+// Reason is the Kratos wallet error reason string, matching one of:
+// INSUFFICIENT_BALANCE, BONUS_BET_LIMIT_EXCEEDED, CASH_BET_LIMIT_EXCEEDED.
+type BetErrorEvent struct {
+	UserID             int64 `json:"user_id"`
+	OperatorID         int64 `json:"operator_id"`
+	CompanyOperatorID  int64 `json:"company_operator_id,omitempty"`
+	RetailerOperatorID int64 `json:"retailer_operator_id,omitempty"`
+	SystemOperatorID   int64 `json:"system_operator_id,omitempty"`
+
+	Reason    string `json:"reason"`
+	GameID    string `json:"game_id"`
+	Currency  string `json:"currency"`
+	BetAmount string `json:"bet_amount"`
+
+	Available   string `json:"available,omitempty"`
+	Required    string `json:"required,omitempty"`
+	LimitAmount string `json:"limit,omitempty"`
+
+	OccurredAt int64 `json:"occurred_at"`
+}


### PR DESCRIPTION
## Summary
- Adds a new `BetErrorEvent` struct to `pkg/events/events.go` for game-service → pubsub → push-service flow
- Covers 3 Kratos wallet reasons: `INSUFFICIENT_BALANCE`, `BONUS_BET_LIMIT_EXCEEDED`, `CASH_BET_LIMIT_EXCEEDED`
- Payload includes user / operator identity, reason, game_id, currency, bet_amount, plus optional structured fields (available, required, limit) extracted from wallet error message

## Context
Today wallet errors only surface at the HTTP bet response. When a bet is provider-initiated or deep-in-game, the frontend doesn't directly receive the error — the user sees unhelpful game UI. This is the first of three PRs that plumbs a real-time toast through push-service's existing pubsub → Centrifugo pattern (same as `wallet_balance_update` / `game_bet`).

## Scope
PR 1/3:
- [x] meepo-api: `BetErrorEvent` struct (this PR)
- [ ] meepo-push-service: pubsub handler + Centrifugo method
- [ ] meepo-game-service: publisher + 2 trigger points in `game_round_pretx.go`

## Test plan
- [x] `go build ./pkg/events/...` passes
- [x] `go vet ./pkg/events/...` clean
- [ ] Downstream consumer PRs (push-service, game-service) compile against this tag