### PR TITLE
feat(wallet): expose deduction_type / cash_ratio / bonus_ratio on GetGamificationConfig

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34416,15 +34416,15 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/api.wallet.service.v1.OperatorCurrencyConfig'
-                deductionType:
+                deductionOrderType:
                     type: string
                     description: '"cash_first", "bonus_first", "mixed"'
                 cashRatio:
                     type: string
-                    description: Decimal string. Only meaningful when deduction_type == "mixed".
+                    description: Decimal string. Only meaningful when deduction_order_type == "mixed".
                 bonusRatio:
                     type: string
-                    description: Decimal string. Only meaningful when deduction_type == "mixed".
+                    description: Decimal string. Only meaningful when deduction_order_type == "mixed".
         api.wallet.service.v1.GetGamificationCurrencyConfigResponse:
             type: object
             properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34421,7 +34421,7 @@ components:
                     description: '"cash_first", "bonus_first", "mixed"'
                 cashRatio:
                     type: string
-                    description: Only meaningful when deduction_type == "mixed". Decimal string.
+                    description: cash_ratio / bonus_ratio are only meaningful when deduction_type == "mixed". Decimal strings.
                 bonusRatio:
                     type: string
         api.wallet.service.v1.GetGamificationCurrencyConfigResponse:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34421,9 +34421,10 @@ components:
                     description: '"cash_first", "bonus_first", "mixed"'
                 cashRatio:
                     type: string
-                    description: cash_ratio / bonus_ratio are only meaningful when deduction_type == "mixed". Decimal strings.
+                    description: Decimal string. Only meaningful when deduction_type == "mixed".
                 bonusRatio:
                     type: string
+                    description: Decimal string. Only meaningful when deduction_type == "mixed".
         api.wallet.service.v1.GetGamificationCurrencyConfigResponse:
             type: object
             properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34416,6 +34416,14 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/api.wallet.service.v1.OperatorCurrencyConfig'
+                deductionType:
+                    type: string
+                    description: '"cash_first", "bonus_first", "mixed"'
+                cashRatio:
+                    type: string
+                    description: Only meaningful when deduction_type == "mixed". Decimal string.
+                bonusRatio:
+                    type: string
         api.wallet.service.v1.GetGamificationCurrencyConfigResponse:
             type: object
             properties:

--- a/wallet/service/v1/wallet.pb.go
+++ b/wallet/service/v1/wallet.pb.go
@@ -8030,9 +8030,14 @@ func (x *GetGamificationConfigRequest) GetCurrencies() []string {
 type GetGamificationConfigResponse struct {
 	state                   protoimpl.MessageState    `protogen:"open.v1"`
 	ClearBonusOnWithdrawal  bool                      `protobuf:"varint,1,opt,name=clear_bonus_on_withdrawal,json=clearBonusOnWithdrawal,proto3" json:"clear_bonus_on_withdrawal,omitempty"`
-	OperatorCurrencyConfigs []*OperatorCurrencyConfig `protobuf:"bytes,2,rep,name=operator_currency_configs,json=operatorCurrencyConfigs,proto3" json:"operator_currency_configs,omitempty"` // NOTE: deduction_type / cash_ratio / bonus_ratio intentionally not exposed to players in v1.
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	OperatorCurrencyConfigs []*OperatorCurrencyConfig `protobuf:"bytes,2,rep,name=operator_currency_configs,json=operatorCurrencyConfigs,proto3" json:"operator_currency_configs,omitempty"`
+	// "cash_first", "bonus_first", "mixed"
+	DeductionType string `protobuf:"bytes,3,opt,name=deduction_type,json=deductionType,proto3" json:"deduction_type,omitempty"`
+	// Only meaningful when deduction_type == "mixed". Decimal string.
+	CashRatio     *string `protobuf:"bytes,4,opt,name=cash_ratio,json=cashRatio,proto3,oneof" json:"cash_ratio,omitempty"`
+	BonusRatio    *string `protobuf:"bytes,5,opt,name=bonus_ratio,json=bonusRatio,proto3,oneof" json:"bonus_ratio,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetGamificationConfigResponse) Reset() {
@@ -8077,6 +8082,27 @@ func (x *GetGamificationConfigResponse) GetOperatorCurrencyConfigs() []*Operator
 		return x.OperatorCurrencyConfigs
 	}
 	return nil
+}
+
+func (x *GetGamificationConfigResponse) GetDeductionType() string {
+	if x != nil {
+		return x.DeductionType
+	}
+	return ""
+}
+
+func (x *GetGamificationConfigResponse) GetCashRatio() string {
+	if x != nil && x.CashRatio != nil {
+		return *x.CashRatio
+	}
+	return ""
+}
+
+func (x *GetGamificationConfigResponse) GetBonusRatio() string {
+	if x != nil && x.BonusRatio != nil {
+		return *x.BonusRatio
+	}
+	return ""
 }
 
 type OperatorCurrencyConfig struct {
@@ -19835,10 +19861,17 @@ const file_wallet_service_v1_wallet_proto_rawDesc = "" +
 	"\x1cGetGamificationConfigRequest\x12\x1e\n" +
 	"\n" +
 	"currencies\x18\x01 \x03(\tR\n" +
-	"currencies\"\xc5\x01\n" +
+	"currencies\"\xd5\x02\n" +
 	"\x1dGetGamificationConfigResponse\x129\n" +
 	"\x19clear_bonus_on_withdrawal\x18\x01 \x01(\bR\x16clearBonusOnWithdrawal\x12i\n" +
-	"\x19operator_currency_configs\x18\x02 \x03(\v2-.api.wallet.service.v1.OperatorCurrencyConfigR\x17operatorCurrencyConfigs\"\xf8\x03\n" +
+	"\x19operator_currency_configs\x18\x02 \x03(\v2-.api.wallet.service.v1.OperatorCurrencyConfigR\x17operatorCurrencyConfigs\x12%\n" +
+	"\x0ededuction_type\x18\x03 \x01(\tR\rdeductionType\x12\"\n" +
+	"\n" +
+	"cash_ratio\x18\x04 \x01(\tH\x00R\tcashRatio\x88\x01\x01\x12$\n" +
+	"\vbonus_ratio\x18\x05 \x01(\tH\x01R\n" +
+	"bonusRatio\x88\x01\x01B\r\n" +
+	"\v_cash_ratioB\x0e\n" +
+	"\f_bonus_ratio\"\xf8\x03\n" +
 	"\x16OperatorCurrencyConfig\x12\x1a\n" +
 	"\bcurrency\x18\x01 \x01(\tR\bcurrency\x12T\n" +
 	"$cash_withdrawal_wagering_requirement\x18\x02 \x01(\x05H\x00R!cashWithdrawalWageringRequirement\x88\x01\x01\x12(\n" +
@@ -21602,6 +21635,7 @@ func file_wallet_service_v1_wallet_proto_init() {
 	file_wallet_service_v1_wallet_proto_msgTypes[77].OneofWrappers = []any{}
 	file_wallet_service_v1_wallet_proto_msgTypes[83].OneofWrappers = []any{}
 	file_wallet_service_v1_wallet_proto_msgTypes[92].OneofWrappers = []any{}
+	file_wallet_service_v1_wallet_proto_msgTypes[96].OneofWrappers = []any{}
 	file_wallet_service_v1_wallet_proto_msgTypes[97].OneofWrappers = []any{}
 	file_wallet_service_v1_wallet_proto_msgTypes[109].OneofWrappers = []any{}
 	file_wallet_service_v1_wallet_proto_msgTypes[112].OneofWrappers = []any{}

--- a/wallet/service/v1/wallet.pb.go
+++ b/wallet/service/v1/wallet.pb.go
@@ -8032,10 +8032,10 @@ type GetGamificationConfigResponse struct {
 	ClearBonusOnWithdrawal  bool                      `protobuf:"varint,1,opt,name=clear_bonus_on_withdrawal,json=clearBonusOnWithdrawal,proto3" json:"clear_bonus_on_withdrawal,omitempty"`
 	OperatorCurrencyConfigs []*OperatorCurrencyConfig `protobuf:"bytes,2,rep,name=operator_currency_configs,json=operatorCurrencyConfigs,proto3" json:"operator_currency_configs,omitempty"`
 	// "cash_first", "bonus_first", "mixed"
-	DeductionType string `protobuf:"bytes,3,opt,name=deduction_type,json=deductionType,proto3" json:"deduction_type,omitempty"`
-	// Decimal string. Only meaningful when deduction_type == "mixed".
+	DeductionOrderType string `protobuf:"bytes,3,opt,name=deduction_order_type,json=deductionOrderType,proto3" json:"deduction_order_type,omitempty"`
+	// Decimal string. Only meaningful when deduction_order_type == "mixed".
 	CashRatio *string `protobuf:"bytes,4,opt,name=cash_ratio,json=cashRatio,proto3,oneof" json:"cash_ratio,omitempty"`
-	// Decimal string. Only meaningful when deduction_type == "mixed".
+	// Decimal string. Only meaningful when deduction_order_type == "mixed".
 	BonusRatio    *string `protobuf:"bytes,5,opt,name=bonus_ratio,json=bonusRatio,proto3,oneof" json:"bonus_ratio,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -8085,9 +8085,9 @@ func (x *GetGamificationConfigResponse) GetOperatorCurrencyConfigs() []*Operator
 	return nil
 }
 
-func (x *GetGamificationConfigResponse) GetDeductionType() string {
+func (x *GetGamificationConfigResponse) GetDeductionOrderType() string {
 	if x != nil {
-		return x.DeductionType
+		return x.DeductionOrderType
 	}
 	return ""
 }
@@ -19862,11 +19862,11 @@ const file_wallet_service_v1_wallet_proto_rawDesc = "" +
 	"\x1cGetGamificationConfigRequest\x12\x1e\n" +
 	"\n" +
 	"currencies\x18\x01 \x03(\tR\n" +
-	"currencies\"\xd5\x02\n" +
+	"currencies\"\xe0\x02\n" +
 	"\x1dGetGamificationConfigResponse\x129\n" +
 	"\x19clear_bonus_on_withdrawal\x18\x01 \x01(\bR\x16clearBonusOnWithdrawal\x12i\n" +
-	"\x19operator_currency_configs\x18\x02 \x03(\v2-.api.wallet.service.v1.OperatorCurrencyConfigR\x17operatorCurrencyConfigs\x12%\n" +
-	"\x0ededuction_type\x18\x03 \x01(\tR\rdeductionType\x12\"\n" +
+	"\x19operator_currency_configs\x18\x02 \x03(\v2-.api.wallet.service.v1.OperatorCurrencyConfigR\x17operatorCurrencyConfigs\x120\n" +
+	"\x14deduction_order_type\x18\x03 \x01(\tR\x12deductionOrderType\x12\"\n" +
 	"\n" +
 	"cash_ratio\x18\x04 \x01(\tH\x00R\tcashRatio\x88\x01\x01\x12$\n" +
 	"\vbonus_ratio\x18\x05 \x01(\tH\x01R\n" +

--- a/wallet/service/v1/wallet.pb.go
+++ b/wallet/service/v1/wallet.pb.go
@@ -8033,8 +8033,9 @@ type GetGamificationConfigResponse struct {
 	OperatorCurrencyConfigs []*OperatorCurrencyConfig `protobuf:"bytes,2,rep,name=operator_currency_configs,json=operatorCurrencyConfigs,proto3" json:"operator_currency_configs,omitempty"`
 	// "cash_first", "bonus_first", "mixed"
 	DeductionType string `protobuf:"bytes,3,opt,name=deduction_type,json=deductionType,proto3" json:"deduction_type,omitempty"`
-	// cash_ratio / bonus_ratio are only meaningful when deduction_type == "mixed". Decimal strings.
-	CashRatio     *string `protobuf:"bytes,4,opt,name=cash_ratio,json=cashRatio,proto3,oneof" json:"cash_ratio,omitempty"`
+	// Decimal string. Only meaningful when deduction_type == "mixed".
+	CashRatio *string `protobuf:"bytes,4,opt,name=cash_ratio,json=cashRatio,proto3,oneof" json:"cash_ratio,omitempty"`
+	// Decimal string. Only meaningful when deduction_type == "mixed".
 	BonusRatio    *string `protobuf:"bytes,5,opt,name=bonus_ratio,json=bonusRatio,proto3,oneof" json:"bonus_ratio,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/wallet/service/v1/wallet.pb.go
+++ b/wallet/service/v1/wallet.pb.go
@@ -8033,7 +8033,7 @@ type GetGamificationConfigResponse struct {
 	OperatorCurrencyConfigs []*OperatorCurrencyConfig `protobuf:"bytes,2,rep,name=operator_currency_configs,json=operatorCurrencyConfigs,proto3" json:"operator_currency_configs,omitempty"`
 	// "cash_first", "bonus_first", "mixed"
 	DeductionType string `protobuf:"bytes,3,opt,name=deduction_type,json=deductionType,proto3" json:"deduction_type,omitempty"`
-	// Only meaningful when deduction_type == "mixed". Decimal string.
+	// cash_ratio / bonus_ratio are only meaningful when deduction_type == "mixed". Decimal strings.
 	CashRatio     *string `protobuf:"bytes,4,opt,name=cash_ratio,json=cashRatio,proto3,oneof" json:"cash_ratio,omitempty"`
 	BonusRatio    *string `protobuf:"bytes,5,opt,name=bonus_ratio,json=bonusRatio,proto3,oneof" json:"bonus_ratio,omitempty"`
 	unknownFields protoimpl.UnknownFields

--- a/wallet/service/v1/wallet.pb.validate.go
+++ b/wallet/service/v1/wallet.pb.validate.go
@@ -14005,6 +14005,16 @@ func (m *GetGamificationConfigResponse) validate(all bool) error {
 
 	}
 
+	// no validation rules for DeductionType
+
+	if m.CashRatio != nil {
+		// no validation rules for CashRatio
+	}
+
+	if m.BonusRatio != nil {
+		// no validation rules for BonusRatio
+	}
+
 	if len(errors) > 0 {
 		return GetGamificationConfigResponseMultiError(errors)
 	}

--- a/wallet/service/v1/wallet.proto
+++ b/wallet/service/v1/wallet.proto
@@ -1521,8 +1521,9 @@ message GetGamificationConfigResponse {
 	repeated OperatorCurrencyConfig operator_currency_configs = 2;
 	// "cash_first", "bonus_first", "mixed"
 	string deduction_type = 3;
-	// cash_ratio / bonus_ratio are only meaningful when deduction_type == "mixed". Decimal strings.
+	// Decimal string. Only meaningful when deduction_type == "mixed".
 	optional string cash_ratio = 4;
+	// Decimal string. Only meaningful when deduction_type == "mixed".
 	optional string bonus_ratio = 5;
 }
 

--- a/wallet/service/v1/wallet.proto
+++ b/wallet/service/v1/wallet.proto
@@ -1520,10 +1520,10 @@ message GetGamificationConfigResponse {
 	bool clear_bonus_on_withdrawal = 1;
 	repeated OperatorCurrencyConfig operator_currency_configs = 2;
 	// "cash_first", "bonus_first", "mixed"
-	string deduction_type = 3;
-	// Decimal string. Only meaningful when deduction_type == "mixed".
+	string deduction_order_type = 3;
+	// Decimal string. Only meaningful when deduction_order_type == "mixed".
 	optional string cash_ratio = 4;
-	// Decimal string. Only meaningful when deduction_type == "mixed".
+	// Decimal string. Only meaningful when deduction_order_type == "mixed".
 	optional string bonus_ratio = 5;
 }
 

--- a/wallet/service/v1/wallet.proto
+++ b/wallet/service/v1/wallet.proto
@@ -1521,7 +1521,7 @@ message GetGamificationConfigResponse {
 	repeated OperatorCurrencyConfig operator_currency_configs = 2;
 	// "cash_first", "bonus_first", "mixed"
 	string deduction_type = 3;
-	// Only meaningful when deduction_type == "mixed". Decimal string.
+	// cash_ratio / bonus_ratio are only meaningful when deduction_type == "mixed". Decimal strings.
 	optional string cash_ratio = 4;
 	optional string bonus_ratio = 5;
 }

--- a/wallet/service/v1/wallet.proto
+++ b/wallet/service/v1/wallet.proto
@@ -1519,7 +1519,11 @@ message GetGamificationConfigRequest {
 message GetGamificationConfigResponse {
 	bool clear_bonus_on_withdrawal = 1;
 	repeated OperatorCurrencyConfig operator_currency_configs = 2;
-	// NOTE: deduction_type / cash_ratio / bonus_ratio intentionally not exposed to players in v1.
+	// "cash_first", "bonus_first", "mixed"
+	string deduction_type = 3;
+	// Only meaningful when deduction_type == "mixed". Decimal string.
+	optional string cash_ratio = 4;
+	optional string bonus_ratio = 5;
 }
 
 message OperatorCurrencyConfig {


### PR DESCRIPTION
## Summary
- Add `deduction_type`, `cash_ratio`, `bonus_ratio` to `GetGamificationConfigResponse` so the player UI can show how bets split between cash and bonus.
- Pure pass-through: the biz layer already loads `walletConfig` via `GetCachedGamificationBundle`, no new DB/cache access required.

## Test plan
- [ ] `make api` regenerates without warnings
- [ ] Downstream `meepo-wallet-service` consumes new fields (follow-up PR)
- [ ] Smoke test `POST /v1/wallet/gamification/config/get` on dev and verify fields match DB values

🤖 Generated with [Claude Code](https://claude.com/claude-code)