### PR TITLE
feat(backoffice): gamification inheritance shape matches wallet pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ task_plan.md
 findings.md
 progress.md
 .git-credentials
+.omc/

--- a/backoffice/service/v1/backoffice_gamification.pb.go
+++ b/backoffice/service/v1/backoffice_gamification.pb.go
@@ -240,6 +240,94 @@ func (x *BackofficeListClaimRulesRequest) GetPageSize() int32 {
 	return 0
 }
 
+// Mirrors the BackofficeWallet inheritance-shape (see GetDepositRewardConfigResponse):
+// the caller's own operator context, the follow_parent toggle, and the page of
+// rules. Each rule already carries `inherited_from_level` indicating whether
+// it was defined at this level or inherited from an ancestor.
+type BackofficeListClaimRulesResponse struct {
+	state                 protoimpl.MessageState  `protogen:"open.v1"`
+	CustomOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=custom_operator_context,json=customOperatorContext,proto3" json:"custom_operator_context,omitempty"`
+	FollowParent          bool                    `protobuf:"varint,2,opt,name=follow_parent,json=followParent,proto3" json:"follow_parent,omitempty"`
+	Rules                 []*v1.ClaimRule         `protobuf:"bytes,3,rep,name=rules,proto3" json:"rules,omitempty"`
+	Total                 int32                   `protobuf:"varint,4,opt,name=total,proto3" json:"total,omitempty"`
+	Page                  int32                   `protobuf:"varint,5,opt,name=page,proto3" json:"page,omitempty"`
+	PageSize              int32                   `protobuf:"varint,6,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *BackofficeListClaimRulesResponse) Reset() {
+	*x = BackofficeListClaimRulesResponse{}
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackofficeListClaimRulesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackofficeListClaimRulesResponse) ProtoMessage() {}
+
+func (x *BackofficeListClaimRulesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackofficeListClaimRulesResponse.ProtoReflect.Descriptor instead.
+func (*BackofficeListClaimRulesResponse) Descriptor() ([]byte, []int) {
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *BackofficeListClaimRulesResponse) GetCustomOperatorContext() *common.OperatorContext {
+	if x != nil {
+		return x.CustomOperatorContext
+	}
+	return nil
+}
+
+func (x *BackofficeListClaimRulesResponse) GetFollowParent() bool {
+	if x != nil {
+		return x.FollowParent
+	}
+	return false
+}
+
+func (x *BackofficeListClaimRulesResponse) GetRules() []*v1.ClaimRule {
+	if x != nil {
+		return x.Rules
+	}
+	return nil
+}
+
+func (x *BackofficeListClaimRulesResponse) GetTotal() int32 {
+	if x != nil {
+		return x.Total
+	}
+	return 0
+}
+
+func (x *BackofficeListClaimRulesResponse) GetPage() int32 {
+	if x != nil {
+		return x.Page
+	}
+	return 0
+}
+
+func (x *BackofficeListClaimRulesResponse) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
 type BackofficeGetClaimRuleRequest struct {
 	state                 protoimpl.MessageState  `protogen:"open.v1"`
 	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
@@ -250,7 +338,7 @@ type BackofficeGetClaimRuleRequest struct {
 
 func (x *BackofficeGetClaimRuleRequest) Reset() {
 	*x = BackofficeGetClaimRuleRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[4]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -262,7 +350,7 @@ func (x *BackofficeGetClaimRuleRequest) String() string {
 func (*BackofficeGetClaimRuleRequest) ProtoMessage() {}
 
 func (x *BackofficeGetClaimRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[4]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -275,7 +363,7 @@ func (x *BackofficeGetClaimRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackofficeGetClaimRuleRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeGetClaimRuleRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{4}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *BackofficeGetClaimRuleRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -303,7 +391,7 @@ type BackofficeUpdateClaimRulePriorityRequest struct {
 
 func (x *BackofficeUpdateClaimRulePriorityRequest) Reset() {
 	*x = BackofficeUpdateClaimRulePriorityRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[5]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -315,7 +403,7 @@ func (x *BackofficeUpdateClaimRulePriorityRequest) String() string {
 func (*BackofficeUpdateClaimRulePriorityRequest) ProtoMessage() {}
 
 func (x *BackofficeUpdateClaimRulePriorityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[5]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -328,7 +416,7 @@ func (x *BackofficeUpdateClaimRulePriorityRequest) ProtoReflect() protoreflect.M
 
 // Deprecated: Use BackofficeUpdateClaimRulePriorityRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeUpdateClaimRulePriorityRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{5}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *BackofficeUpdateClaimRulePriorityRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -363,7 +451,7 @@ type BackofficeUpdateClaimRuleStatusRequest struct {
 
 func (x *BackofficeUpdateClaimRuleStatusRequest) Reset() {
 	*x = BackofficeUpdateClaimRuleStatusRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[6]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -375,7 +463,7 @@ func (x *BackofficeUpdateClaimRuleStatusRequest) String() string {
 func (*BackofficeUpdateClaimRuleStatusRequest) ProtoMessage() {}
 
 func (x *BackofficeUpdateClaimRuleStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[6]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -388,7 +476,7 @@ func (x *BackofficeUpdateClaimRuleStatusRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use BackofficeUpdateClaimRuleStatusRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeUpdateClaimRuleStatusRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{6}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *BackofficeUpdateClaimRuleStatusRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -412,6 +500,94 @@ func (x *BackofficeUpdateClaimRuleStatusRequest) GetStatus() v1.RuleStatus {
 	return v1.RuleStatus(0)
 }
 
+type BackofficeSetClaimRuleFollowParentRequest struct {
+	state                 protoimpl.MessageState  `protogen:"open.v1"`
+	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
+	FollowParent          bool                    `protobuf:"varint,2,opt,name=follow_parent,json=followParent,proto3" json:"follow_parent,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *BackofficeSetClaimRuleFollowParentRequest) Reset() {
+	*x = BackofficeSetClaimRuleFollowParentRequest{}
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackofficeSetClaimRuleFollowParentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackofficeSetClaimRuleFollowParentRequest) ProtoMessage() {}
+
+func (x *BackofficeSetClaimRuleFollowParentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackofficeSetClaimRuleFollowParentRequest.ProtoReflect.Descriptor instead.
+func (*BackofficeSetClaimRuleFollowParentRequest) Descriptor() ([]byte, []int) {
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *BackofficeSetClaimRuleFollowParentRequest) GetTargetOperatorContext() *common.OperatorContext {
+	if x != nil {
+		return x.TargetOperatorContext
+	}
+	return nil
+}
+
+func (x *BackofficeSetClaimRuleFollowParentRequest) GetFollowParent() bool {
+	if x != nil {
+		return x.FollowParent
+	}
+	return false
+}
+
+type BackofficeSetClaimRuleFollowParentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BackofficeSetClaimRuleFollowParentResponse) Reset() {
+	*x = BackofficeSetClaimRuleFollowParentResponse{}
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackofficeSetClaimRuleFollowParentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackofficeSetClaimRuleFollowParentResponse) ProtoMessage() {}
+
+func (x *BackofficeSetClaimRuleFollowParentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackofficeSetClaimRuleFollowParentResponse.ProtoReflect.Descriptor instead.
+func (*BackofficeSetClaimRuleFollowParentResponse) Descriptor() ([]byte, []int) {
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{9}
+}
+
 type BackofficeCreateGameRestrictionRuleRequest struct {
 	state                 protoimpl.MessageState  `protogen:"open.v1"`
 	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
@@ -422,7 +598,7 @@ type BackofficeCreateGameRestrictionRuleRequest struct {
 
 func (x *BackofficeCreateGameRestrictionRuleRequest) Reset() {
 	*x = BackofficeCreateGameRestrictionRuleRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[7]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -434,7 +610,7 @@ func (x *BackofficeCreateGameRestrictionRuleRequest) String() string {
 func (*BackofficeCreateGameRestrictionRuleRequest) ProtoMessage() {}
 
 func (x *BackofficeCreateGameRestrictionRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[7]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -447,7 +623,7 @@ func (x *BackofficeCreateGameRestrictionRuleRequest) ProtoReflect() protoreflect
 
 // Deprecated: Use BackofficeCreateGameRestrictionRuleRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeCreateGameRestrictionRuleRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{7}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *BackofficeCreateGameRestrictionRuleRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -474,7 +650,7 @@ type BackofficeUpdateGameRestrictionRuleRequest struct {
 
 func (x *BackofficeUpdateGameRestrictionRuleRequest) Reset() {
 	*x = BackofficeUpdateGameRestrictionRuleRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[8]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -486,7 +662,7 @@ func (x *BackofficeUpdateGameRestrictionRuleRequest) String() string {
 func (*BackofficeUpdateGameRestrictionRuleRequest) ProtoMessage() {}
 
 func (x *BackofficeUpdateGameRestrictionRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[8]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -499,7 +675,7 @@ func (x *BackofficeUpdateGameRestrictionRuleRequest) ProtoReflect() protoreflect
 
 // Deprecated: Use BackofficeUpdateGameRestrictionRuleRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeUpdateGameRestrictionRuleRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{8}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *BackofficeUpdateGameRestrictionRuleRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -526,7 +702,7 @@ type BackofficeDeleteGameRestrictionRuleRequest struct {
 
 func (x *BackofficeDeleteGameRestrictionRuleRequest) Reset() {
 	*x = BackofficeDeleteGameRestrictionRuleRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[9]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -538,7 +714,7 @@ func (x *BackofficeDeleteGameRestrictionRuleRequest) String() string {
 func (*BackofficeDeleteGameRestrictionRuleRequest) ProtoMessage() {}
 
 func (x *BackofficeDeleteGameRestrictionRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[9]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -551,7 +727,7 @@ func (x *BackofficeDeleteGameRestrictionRuleRequest) ProtoReflect() protoreflect
 
 // Deprecated: Use BackofficeDeleteGameRestrictionRuleRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeDeleteGameRestrictionRuleRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{9}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *BackofficeDeleteGameRestrictionRuleRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -579,7 +755,7 @@ type BackofficeListGameRestrictionRulesRequest struct {
 
 func (x *BackofficeListGameRestrictionRulesRequest) Reset() {
 	*x = BackofficeListGameRestrictionRulesRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[10]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -591,7 +767,7 @@ func (x *BackofficeListGameRestrictionRulesRequest) String() string {
 func (*BackofficeListGameRestrictionRulesRequest) ProtoMessage() {}
 
 func (x *BackofficeListGameRestrictionRulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[10]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -604,7 +780,7 @@ func (x *BackofficeListGameRestrictionRulesRequest) ProtoReflect() protoreflect.
 
 // Deprecated: Use BackofficeListGameRestrictionRulesRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeListGameRestrictionRulesRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{10}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *BackofficeListGameRestrictionRulesRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -628,6 +804,90 @@ func (x *BackofficeListGameRestrictionRulesRequest) GetPageSize() int32 {
 	return 0
 }
 
+type BackofficeListGameRestrictionRulesResponse struct {
+	state                 protoimpl.MessageState    `protogen:"open.v1"`
+	CustomOperatorContext *common.OperatorContext   `protobuf:"bytes,1,opt,name=custom_operator_context,json=customOperatorContext,proto3" json:"custom_operator_context,omitempty"`
+	FollowParent          bool                      `protobuf:"varint,2,opt,name=follow_parent,json=followParent,proto3" json:"follow_parent,omitempty"`
+	Rules                 []*v1.GameRestrictionRule `protobuf:"bytes,3,rep,name=rules,proto3" json:"rules,omitempty"`
+	Total                 int32                     `protobuf:"varint,4,opt,name=total,proto3" json:"total,omitempty"`
+	Page                  int32                     `protobuf:"varint,5,opt,name=page,proto3" json:"page,omitempty"`
+	PageSize              int32                     `protobuf:"varint,6,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *BackofficeListGameRestrictionRulesResponse) Reset() {
+	*x = BackofficeListGameRestrictionRulesResponse{}
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackofficeListGameRestrictionRulesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackofficeListGameRestrictionRulesResponse) ProtoMessage() {}
+
+func (x *BackofficeListGameRestrictionRulesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackofficeListGameRestrictionRulesResponse.ProtoReflect.Descriptor instead.
+func (*BackofficeListGameRestrictionRulesResponse) Descriptor() ([]byte, []int) {
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *BackofficeListGameRestrictionRulesResponse) GetCustomOperatorContext() *common.OperatorContext {
+	if x != nil {
+		return x.CustomOperatorContext
+	}
+	return nil
+}
+
+func (x *BackofficeListGameRestrictionRulesResponse) GetFollowParent() bool {
+	if x != nil {
+		return x.FollowParent
+	}
+	return false
+}
+
+func (x *BackofficeListGameRestrictionRulesResponse) GetRules() []*v1.GameRestrictionRule {
+	if x != nil {
+		return x.Rules
+	}
+	return nil
+}
+
+func (x *BackofficeListGameRestrictionRulesResponse) GetTotal() int32 {
+	if x != nil {
+		return x.Total
+	}
+	return 0
+}
+
+func (x *BackofficeListGameRestrictionRulesResponse) GetPage() int32 {
+	if x != nil {
+		return x.Page
+	}
+	return 0
+}
+
+func (x *BackofficeListGameRestrictionRulesResponse) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
 type BackofficeGetGameRestrictionRuleRequest struct {
 	state                 protoimpl.MessageState  `protogen:"open.v1"`
 	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
@@ -638,7 +898,7 @@ type BackofficeGetGameRestrictionRuleRequest struct {
 
 func (x *BackofficeGetGameRestrictionRuleRequest) Reset() {
 	*x = BackofficeGetGameRestrictionRuleRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[11]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -650,7 +910,7 @@ func (x *BackofficeGetGameRestrictionRuleRequest) String() string {
 func (*BackofficeGetGameRestrictionRuleRequest) ProtoMessage() {}
 
 func (x *BackofficeGetGameRestrictionRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[11]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -663,7 +923,7 @@ func (x *BackofficeGetGameRestrictionRuleRequest) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use BackofficeGetGameRestrictionRuleRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeGetGameRestrictionRuleRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{11}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *BackofficeGetGameRestrictionRuleRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -691,7 +951,7 @@ type BackofficeUpdateGameRestrictionRulePriorityRequest struct {
 
 func (x *BackofficeUpdateGameRestrictionRulePriorityRequest) Reset() {
 	*x = BackofficeUpdateGameRestrictionRulePriorityRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[12]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -703,7 +963,7 @@ func (x *BackofficeUpdateGameRestrictionRulePriorityRequest) String() string {
 func (*BackofficeUpdateGameRestrictionRulePriorityRequest) ProtoMessage() {}
 
 func (x *BackofficeUpdateGameRestrictionRulePriorityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[12]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -716,7 +976,7 @@ func (x *BackofficeUpdateGameRestrictionRulePriorityRequest) ProtoReflect() prot
 
 // Deprecated: Use BackofficeUpdateGameRestrictionRulePriorityRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeUpdateGameRestrictionRulePriorityRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{12}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *BackofficeUpdateGameRestrictionRulePriorityRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -751,7 +1011,7 @@ type BackofficeUpdateGameRestrictionRuleStatusRequest struct {
 
 func (x *BackofficeUpdateGameRestrictionRuleStatusRequest) Reset() {
 	*x = BackofficeUpdateGameRestrictionRuleStatusRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[13]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -763,7 +1023,7 @@ func (x *BackofficeUpdateGameRestrictionRuleStatusRequest) String() string {
 func (*BackofficeUpdateGameRestrictionRuleStatusRequest) ProtoMessage() {}
 
 func (x *BackofficeUpdateGameRestrictionRuleStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[13]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -776,7 +1036,7 @@ func (x *BackofficeUpdateGameRestrictionRuleStatusRequest) ProtoReflect() protor
 
 // Deprecated: Use BackofficeUpdateGameRestrictionRuleStatusRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeUpdateGameRestrictionRuleStatusRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{13}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *BackofficeUpdateGameRestrictionRuleStatusRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -800,6 +1060,94 @@ func (x *BackofficeUpdateGameRestrictionRuleStatusRequest) GetStatus() v1.RuleSt
 	return v1.RuleStatus(0)
 }
 
+type BackofficeSetGameRestrictionRuleFollowParentRequest struct {
+	state                 protoimpl.MessageState  `protogen:"open.v1"`
+	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
+	FollowParent          bool                    `protobuf:"varint,2,opt,name=follow_parent,json=followParent,proto3" json:"follow_parent,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *BackofficeSetGameRestrictionRuleFollowParentRequest) Reset() {
+	*x = BackofficeSetGameRestrictionRuleFollowParentRequest{}
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackofficeSetGameRestrictionRuleFollowParentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackofficeSetGameRestrictionRuleFollowParentRequest) ProtoMessage() {}
+
+func (x *BackofficeSetGameRestrictionRuleFollowParentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackofficeSetGameRestrictionRuleFollowParentRequest.ProtoReflect.Descriptor instead.
+func (*BackofficeSetGameRestrictionRuleFollowParentRequest) Descriptor() ([]byte, []int) {
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *BackofficeSetGameRestrictionRuleFollowParentRequest) GetTargetOperatorContext() *common.OperatorContext {
+	if x != nil {
+		return x.TargetOperatorContext
+	}
+	return nil
+}
+
+func (x *BackofficeSetGameRestrictionRuleFollowParentRequest) GetFollowParent() bool {
+	if x != nil {
+		return x.FollowParent
+	}
+	return false
+}
+
+type BackofficeSetGameRestrictionRuleFollowParentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BackofficeSetGameRestrictionRuleFollowParentResponse) Reset() {
+	*x = BackofficeSetGameRestrictionRuleFollowParentResponse{}
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackofficeSetGameRestrictionRuleFollowParentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackofficeSetGameRestrictionRuleFollowParentResponse) ProtoMessage() {}
+
+func (x *BackofficeSetGameRestrictionRuleFollowParentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackofficeSetGameRestrictionRuleFollowParentResponse.ProtoReflect.Descriptor instead.
+func (*BackofficeSetGameRestrictionRuleFollowParentResponse) Descriptor() ([]byte, []int) {
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{19}
+}
+
 type BackofficeGetBonusBuyConfigRequest struct {
 	state                 protoimpl.MessageState  `protogen:"open.v1"`
 	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
@@ -809,7 +1157,7 @@ type BackofficeGetBonusBuyConfigRequest struct {
 
 func (x *BackofficeGetBonusBuyConfigRequest) Reset() {
 	*x = BackofficeGetBonusBuyConfigRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[14]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -821,7 +1169,7 @@ func (x *BackofficeGetBonusBuyConfigRequest) String() string {
 func (*BackofficeGetBonusBuyConfigRequest) ProtoMessage() {}
 
 func (x *BackofficeGetBonusBuyConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[14]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -834,7 +1182,7 @@ func (x *BackofficeGetBonusBuyConfigRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use BackofficeGetBonusBuyConfigRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeGetBonusBuyConfigRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{14}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *BackofficeGetBonusBuyConfigRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -854,7 +1202,7 @@ type BackofficeUpdateBonusBuyConfigRequest struct {
 
 func (x *BackofficeUpdateBonusBuyConfigRequest) Reset() {
 	*x = BackofficeUpdateBonusBuyConfigRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[15]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -866,7 +1214,7 @@ func (x *BackofficeUpdateBonusBuyConfigRequest) String() string {
 func (*BackofficeUpdateBonusBuyConfigRequest) ProtoMessage() {}
 
 func (x *BackofficeUpdateBonusBuyConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[15]
+	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -879,7 +1227,7 @@ func (x *BackofficeUpdateBonusBuyConfigRequest) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use BackofficeUpdateBonusBuyConfigRequest.ProtoReflect.Descriptor instead.
 func (*BackofficeUpdateBonusBuyConfigRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{15}
+	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *BackofficeUpdateBonusBuyConfigRequest) GetTargetOperatorContext() *common.OperatorContext {
@@ -892,120 +1240,6 @@ func (x *BackofficeUpdateBonusBuyConfigRequest) GetTargetOperatorContext() *comm
 func (x *BackofficeUpdateBonusBuyConfigRequest) GetEnabled() bool {
 	if x != nil {
 		return x.Enabled
-	}
-	return false
-}
-
-type BackofficeGetRuleHierarchyConfigRequest struct {
-	state                 protoimpl.MessageState  `protogen:"open.v1"`
-	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
-	// "claim_rule" | "game_restriction_rule"
-	RuleType      string `protobuf:"bytes,2,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *BackofficeGetRuleHierarchyConfigRequest) Reset() {
-	*x = BackofficeGetRuleHierarchyConfigRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[16]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *BackofficeGetRuleHierarchyConfigRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*BackofficeGetRuleHierarchyConfigRequest) ProtoMessage() {}
-
-func (x *BackofficeGetRuleHierarchyConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[16]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use BackofficeGetRuleHierarchyConfigRequest.ProtoReflect.Descriptor instead.
-func (*BackofficeGetRuleHierarchyConfigRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{16}
-}
-
-func (x *BackofficeGetRuleHierarchyConfigRequest) GetTargetOperatorContext() *common.OperatorContext {
-	if x != nil {
-		return x.TargetOperatorContext
-	}
-	return nil
-}
-
-func (x *BackofficeGetRuleHierarchyConfigRequest) GetRuleType() string {
-	if x != nil {
-		return x.RuleType
-	}
-	return ""
-}
-
-type BackofficeUpdateRuleHierarchyConfigRequest struct {
-	state                 protoimpl.MessageState  `protogen:"open.v1"`
-	TargetOperatorContext *common.OperatorContext `protobuf:"bytes,1,opt,name=target_operator_context,json=targetOperatorContext,proto3" json:"target_operator_context,omitempty"`
-	// "claim_rule" | "game_restriction_rule"
-	RuleType      string `protobuf:"bytes,2,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
-	FollowParent  bool   `protobuf:"varint,3,opt,name=follow_parent,json=followParent,proto3" json:"follow_parent,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *BackofficeUpdateRuleHierarchyConfigRequest) Reset() {
-	*x = BackofficeUpdateRuleHierarchyConfigRequest{}
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[17]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *BackofficeUpdateRuleHierarchyConfigRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*BackofficeUpdateRuleHierarchyConfigRequest) ProtoMessage() {}
-
-func (x *BackofficeUpdateRuleHierarchyConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_backoffice_service_v1_backoffice_gamification_proto_msgTypes[17]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use BackofficeUpdateRuleHierarchyConfigRequest.ProtoReflect.Descriptor instead.
-func (*BackofficeUpdateRuleHierarchyConfigRequest) Descriptor() ([]byte, []int) {
-	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP(), []int{17}
-}
-
-func (x *BackofficeUpdateRuleHierarchyConfigRequest) GetTargetOperatorContext() *common.OperatorContext {
-	if x != nil {
-		return x.TargetOperatorContext
-	}
-	return nil
-}
-
-func (x *BackofficeUpdateRuleHierarchyConfigRequest) GetRuleType() string {
-	if x != nil {
-		return x.RuleType
-	}
-	return ""
-}
-
-func (x *BackofficeUpdateRuleHierarchyConfigRequest) GetFollowParent() bool {
-	if x != nil {
-		return x.FollowParent
 	}
 	return false
 }
@@ -1027,7 +1261,14 @@ const file_backoffice_service_v1_backoffice_gamification_proto_rawDesc = "" +
 	"\x1fBackofficeListClaimRulesRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x12\n" +
 	"\x04page\x18\x02 \x01(\x05R\x04page\x12\x1b\n" +
-	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\"\x8d\x01\n" +
+	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\"\xa1\x02\n" +
+	" BackofficeListClaimRulesResponse\x12S\n" +
+	"\x17custom_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15customOperatorContext\x12#\n" +
+	"\rfollow_parent\x18\x02 \x01(\bR\ffollowParent\x12<\n" +
+	"\x05rules\x18\x03 \x03(\v2&.api.gamification.service.v1.ClaimRuleR\x05rules\x12\x14\n" +
+	"\x05total\x18\x04 \x01(\x05R\x05total\x12\x12\n" +
+	"\x04page\x18\x05 \x01(\x05R\x04page\x12\x1b\n" +
+	"\tpage_size\x18\x06 \x01(\x05R\bpageSize\"\x8d\x01\n" +
 	"\x1dBackofficeGetClaimRuleRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x17\n" +
 	"\arule_id\x18\x02 \x01(\x03R\x06ruleId\"\xb4\x01\n" +
@@ -1038,7 +1279,11 @@ const file_backoffice_service_v1_backoffice_gamification_proto_rawDesc = "" +
 	"&BackofficeUpdateClaimRuleStatusRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x17\n" +
 	"\arule_id\x18\x02 \x01(\x03R\x06ruleId\x12?\n" +
-	"\x06status\x18\x03 \x01(\x0e2'.api.gamification.service.v1.RuleStatusR\x06status\"\xc7\x01\n" +
+	"\x06status\x18\x03 \x01(\x0e2'.api.gamification.service.v1.RuleStatusR\x06status\"\xa5\x01\n" +
+	")BackofficeSetClaimRuleFollowParentRequest\x12S\n" +
+	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12#\n" +
+	"\rfollow_parent\x18\x02 \x01(\bR\ffollowParent\",\n" +
+	"*BackofficeSetClaimRuleFollowParentResponse\"\xc7\x01\n" +
 	"*BackofficeCreateGameRestrictionRuleRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12D\n" +
 	"\x04rule\x18\x02 \x01(\v20.api.gamification.service.v1.GameRestrictionRuleR\x04rule\"\xc7\x01\n" +
@@ -1051,7 +1296,14 @@ const file_backoffice_service_v1_backoffice_gamification_proto_rawDesc = "" +
 	")BackofficeListGameRestrictionRulesRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x12\n" +
 	"\x04page\x18\x02 \x01(\x05R\x04page\x12\x1b\n" +
-	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\"\x97\x01\n" +
+	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\"\xb5\x02\n" +
+	"*BackofficeListGameRestrictionRulesResponse\x12S\n" +
+	"\x17custom_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15customOperatorContext\x12#\n" +
+	"\rfollow_parent\x18\x02 \x01(\bR\ffollowParent\x12F\n" +
+	"\x05rules\x18\x03 \x03(\v20.api.gamification.service.v1.GameRestrictionRuleR\x05rules\x12\x14\n" +
+	"\x05total\x18\x04 \x01(\x05R\x05total\x12\x12\n" +
+	"\x04page\x18\x05 \x01(\x05R\x04page\x12\x1b\n" +
+	"\tpage_size\x18\x06 \x01(\x05R\bpageSize\"\x97\x01\n" +
 	"'BackofficeGetGameRestrictionRuleRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x17\n" +
 	"\arule_id\x18\x02 \x01(\x03R\x06ruleId\"\xbe\x01\n" +
@@ -1062,38 +1314,35 @@ const file_backoffice_service_v1_backoffice_gamification_proto_rawDesc = "" +
 	"0BackofficeUpdateGameRestrictionRuleStatusRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x17\n" +
 	"\arule_id\x18\x02 \x01(\x03R\x06ruleId\x12?\n" +
-	"\x06status\x18\x03 \x01(\x0e2'.api.gamification.service.v1.RuleStatusR\x06status\"y\n" +
+	"\x06status\x18\x03 \x01(\x0e2'.api.gamification.service.v1.RuleStatusR\x06status\"\xaf\x01\n" +
+	"3BackofficeSetGameRestrictionRuleFollowParentRequest\x12S\n" +
+	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12#\n" +
+	"\rfollow_parent\x18\x02 \x01(\bR\ffollowParent\"6\n" +
+	"4BackofficeSetGameRestrictionRuleFollowParentResponse\"y\n" +
 	"\"BackofficeGetBonusBuyConfigRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\"\x96\x01\n" +
 	"%BackofficeUpdateBonusBuyConfigRequest\x12S\n" +
 	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x18\n" +
-	"\aenabled\x18\x02 \x01(\bR\aenabled\"\x9b\x01\n" +
-	"'BackofficeGetRuleHierarchyConfigRequest\x12S\n" +
-	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x1b\n" +
-	"\trule_type\x18\x02 \x01(\tR\bruleType\"\xc3\x01\n" +
-	"*BackofficeUpdateRuleHierarchyConfigRequest\x12S\n" +
-	"\x17target_operator_context\x18\x01 \x01(\v2\x1b.api.common.OperatorContextR\x15targetOperatorContext\x12\x1b\n" +
-	"\trule_type\x18\x02 \x01(\tR\bruleType\x12#\n" +
-	"\rfollow_parent\x18\x03 \x01(\bR\ffollowParent2\xff\x1e\n" +
+	"\aenabled\x18\x02 \x01(\bR\aenabled2\xce\x1f\n" +
 	"\x16BackofficeGamification\x12\xbe\x01\n" +
 	"\x0fCreateClaimRule\x12;.api.backoffice.service.v1.BackofficeCreateClaimRuleRequest\x1a4.api.gamification.service.v1.CreateClaimRuleResponse\"8\x82\xd3\xe4\x93\x022:\x01*\"-/v1/backoffice/gamification/claim-rule/create\x12\xbe\x01\n" +
 	"\x0fUpdateClaimRule\x12;.api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest\x1a4.api.gamification.service.v1.UpdateClaimRuleResponse\"8\x82\xd3\xe4\x93\x022:\x01*\"-/v1/backoffice/gamification/claim-rule/update\x12\xbe\x01\n" +
-	"\x0fDeleteClaimRule\x12;.api.backoffice.service.v1.BackofficeDeleteClaimRuleRequest\x1a4.api.gamification.service.v1.DeleteClaimRuleResponse\"8\x82\xd3\xe4\x93\x022:\x01*\"-/v1/backoffice/gamification/claim-rule/delete\x12\xb9\x01\n" +
-	"\x0eListClaimRules\x12:.api.backoffice.service.v1.BackofficeListClaimRulesRequest\x1a3.api.gamification.service.v1.ListClaimRulesResponse\"6\x82\xd3\xe4\x93\x020:\x01*\"+/v1/backoffice/gamification/claim-rule/list\x12\xb2\x01\n" +
+	"\x0fDeleteClaimRule\x12;.api.backoffice.service.v1.BackofficeDeleteClaimRuleRequest\x1a4.api.gamification.service.v1.DeleteClaimRuleResponse\"8\x82\xd3\xe4\x93\x022:\x01*\"-/v1/backoffice/gamification/claim-rule/delete\x12\xc1\x01\n" +
+	"\x0eListClaimRules\x12:.api.backoffice.service.v1.BackofficeListClaimRulesRequest\x1a;.api.backoffice.service.v1.BackofficeListClaimRulesResponse\"6\x82\xd3\xe4\x93\x020:\x01*\"+/v1/backoffice/gamification/claim-rule/list\x12\xb2\x01\n" +
 	"\fGetClaimRule\x128.api.backoffice.service.v1.BackofficeGetClaimRuleRequest\x1a1.api.gamification.service.v1.GetClaimRuleResponse\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/backoffice/gamification/claim-rule/get\x12\xdf\x01\n" +
 	"\x17UpdateClaimRulePriority\x12C.api.backoffice.service.v1.BackofficeUpdateClaimRulePriorityRequest\x1a<.api.gamification.service.v1.UpdateClaimRulePriorityResponse\"A\x82\xd3\xe4\x93\x02;:\x01*\"6/v1/backoffice/gamification/claim-rule/priority/update\x12\xd7\x01\n" +
-	"\x15UpdateClaimRuleStatus\x12A.api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest\x1a:.api.gamification.service.v1.UpdateClaimRuleStatusResponse\"?\x82\xd3\xe4\x93\x029:\x01*\"4/v1/backoffice/gamification/claim-rule/status/update\x12\xe7\x01\n" +
+	"\x15UpdateClaimRuleStatus\x12A.api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest\x1a:.api.gamification.service.v1.UpdateClaimRuleStatusResponse\"?\x82\xd3\xe4\x93\x029:\x01*\"4/v1/backoffice/gamification/claim-rule/status/update\x12\xec\x01\n" +
+	"\x18SetClaimRuleFollowParent\x12D.api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentRequest\x1aE.api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/backoffice/gamification/claim-rule/follow-parent/set\x12\xe7\x01\n" +
 	"\x19CreateGameRestrictionRule\x12E.api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest\x1a>.api.gamification.service.v1.CreateGameRestrictionRuleResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/backoffice/gamification/game-restriction-rule/create\x12\xe7\x01\n" +
 	"\x19UpdateGameRestrictionRule\x12E.api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest\x1a>.api.gamification.service.v1.UpdateGameRestrictionRuleResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/backoffice/gamification/game-restriction-rule/update\x12\xe7\x01\n" +
-	"\x19DeleteGameRestrictionRule\x12E.api.backoffice.service.v1.BackofficeDeleteGameRestrictionRuleRequest\x1a>.api.gamification.service.v1.DeleteGameRestrictionRuleResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/backoffice/gamification/game-restriction-rule/delete\x12\xe2\x01\n" +
-	"\x18ListGameRestrictionRules\x12D.api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest\x1a=.api.gamification.service.v1.ListGameRestrictionRulesResponse\"A\x82\xd3\xe4\x93\x02;:\x01*\"6/v1/backoffice/gamification/game-restriction-rule/list\x12\xdb\x01\n" +
+	"\x19DeleteGameRestrictionRule\x12E.api.backoffice.service.v1.BackofficeDeleteGameRestrictionRuleRequest\x1a>.api.gamification.service.v1.DeleteGameRestrictionRuleResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/backoffice/gamification/game-restriction-rule/delete\x12\xea\x01\n" +
+	"\x18ListGameRestrictionRules\x12D.api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest\x1aE.api.backoffice.service.v1.BackofficeListGameRestrictionRulesResponse\"A\x82\xd3\xe4\x93\x02;:\x01*\"6/v1/backoffice/gamification/game-restriction-rule/list\x12\xdb\x01\n" +
 	"\x16GetGameRestrictionRule\x12B.api.backoffice.service.v1.BackofficeGetGameRestrictionRuleRequest\x1a;.api.gamification.service.v1.GetGameRestrictionRuleResponse\"@\x82\xd3\xe4\x93\x02::\x01*\"5/v1/backoffice/gamification/game-restriction-rule/get\x12\x88\x02\n" +
 	"!UpdateGameRestrictionRulePriority\x12M.api.backoffice.service.v1.BackofficeUpdateGameRestrictionRulePriorityRequest\x1aF.api.gamification.service.v1.UpdateGameRestrictionRulePriorityResponse\"L\x82\xd3\xe4\x93\x02F:\x01*\"A/v1/backoffice/gamification/game-restriction-rule/priority/update\x12\x80\x02\n" +
-	"\x1fUpdateGameRestrictionRuleStatus\x12K.api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest\x1aD.api.gamification.service.v1.UpdateGameRestrictionRuleStatusResponse\"J\x82\xd3\xe4\x93\x02D:\x01*\"?/v1/backoffice/gamification/game-restriction-rule/status/update\x12\xc7\x01\n" +
+	"\x1fUpdateGameRestrictionRuleStatus\x12K.api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest\x1aD.api.gamification.service.v1.UpdateGameRestrictionRuleStatusResponse\"J\x82\xd3\xe4\x93\x02D:\x01*\"?/v1/backoffice/gamification/game-restriction-rule/status/update\x12\x95\x02\n" +
+	"\"SetGameRestrictionRuleFollowParent\x12N.api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentRequest\x1aO.api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentResponse\"N\x82\xd3\xe4\x93\x02H:\x01*\"C/v1/backoffice/gamification/game-restriction-rule/follow-parent/set\x12\xc7\x01\n" +
 	"\x11GetBonusBuyConfig\x12=.api.backoffice.service.v1.BackofficeGetBonusBuyConfigRequest\x1a6.api.gamification.service.v1.GetBonusBuyConfigResponse\";\x82\xd3\xe4\x93\x025:\x01*\"0/v1/backoffice/gamification/bonus-buy-config/get\x12\xd3\x01\n" +
-	"\x14UpdateBonusBuyConfig\x12@.api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest\x1a9.api.gamification.service.v1.UpdateBonusBuyConfigResponse\">\x82\xd3\xe4\x93\x028:\x01*\"3/v1/backoffice/gamification/bonus-buy-config/update\x12\xdb\x01\n" +
-	"\x16GetRuleHierarchyConfig\x12B.api.backoffice.service.v1.BackofficeGetRuleHierarchyConfigRequest\x1a;.api.gamification.service.v1.GetRuleHierarchyConfigResponse\"@\x82\xd3\xe4\x93\x02::\x01*\"5/v1/backoffice/gamification/rule-hierarchy-config/get\x12\xe7\x01\n" +
-	"\x19UpdateRuleHierarchyConfig\x12E.api.backoffice.service.v1.BackofficeUpdateRuleHierarchyConfigRequest\x1a>.api.gamification.service.v1.UpdateRuleHierarchyConfigResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/backoffice/gamification/rule-hierarchy-config/updateB[\n" +
+	"\x14UpdateBonusBuyConfig\x12@.api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest\x1a9.api.gamification.service.v1.UpdateBonusBuyConfigResponse\">\x82\xd3\xe4\x93\x028:\x01*\"3/v1/backoffice/gamification/bonus-buy-config/updateB[\n" +
 	"\x19api.backoffice.service.v1P\x01Z<github.com/infigaming-com/meepo-api/backoffice/service/v1;v1b\x06proto3"
 
 var (
@@ -1108,115 +1357,119 @@ func file_backoffice_service_v1_backoffice_gamification_proto_rawDescGZIP() []by
 	return file_backoffice_service_v1_backoffice_gamification_proto_rawDescData
 }
 
-var file_backoffice_service_v1_backoffice_gamification_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_backoffice_service_v1_backoffice_gamification_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_backoffice_service_v1_backoffice_gamification_proto_goTypes = []any{
-	(*BackofficeCreateClaimRuleRequest)(nil),                   // 0: api.backoffice.service.v1.BackofficeCreateClaimRuleRequest
-	(*BackofficeUpdateClaimRuleRequest)(nil),                   // 1: api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest
-	(*BackofficeDeleteClaimRuleRequest)(nil),                   // 2: api.backoffice.service.v1.BackofficeDeleteClaimRuleRequest
-	(*BackofficeListClaimRulesRequest)(nil),                    // 3: api.backoffice.service.v1.BackofficeListClaimRulesRequest
-	(*BackofficeGetClaimRuleRequest)(nil),                      // 4: api.backoffice.service.v1.BackofficeGetClaimRuleRequest
-	(*BackofficeUpdateClaimRulePriorityRequest)(nil),           // 5: api.backoffice.service.v1.BackofficeUpdateClaimRulePriorityRequest
-	(*BackofficeUpdateClaimRuleStatusRequest)(nil),             // 6: api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest
-	(*BackofficeCreateGameRestrictionRuleRequest)(nil),         // 7: api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest
-	(*BackofficeUpdateGameRestrictionRuleRequest)(nil),         // 8: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest
-	(*BackofficeDeleteGameRestrictionRuleRequest)(nil),         // 9: api.backoffice.service.v1.BackofficeDeleteGameRestrictionRuleRequest
-	(*BackofficeListGameRestrictionRulesRequest)(nil),          // 10: api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest
-	(*BackofficeGetGameRestrictionRuleRequest)(nil),            // 11: api.backoffice.service.v1.BackofficeGetGameRestrictionRuleRequest
-	(*BackofficeUpdateGameRestrictionRulePriorityRequest)(nil), // 12: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRulePriorityRequest
-	(*BackofficeUpdateGameRestrictionRuleStatusRequest)(nil),   // 13: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest
-	(*BackofficeGetBonusBuyConfigRequest)(nil),                 // 14: api.backoffice.service.v1.BackofficeGetBonusBuyConfigRequest
-	(*BackofficeUpdateBonusBuyConfigRequest)(nil),              // 15: api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest
-	(*BackofficeGetRuleHierarchyConfigRequest)(nil),            // 16: api.backoffice.service.v1.BackofficeGetRuleHierarchyConfigRequest
-	(*BackofficeUpdateRuleHierarchyConfigRequest)(nil),         // 17: api.backoffice.service.v1.BackofficeUpdateRuleHierarchyConfigRequest
-	(*common.OperatorContext)(nil),                             // 18: api.common.OperatorContext
-	(*v1.ClaimRule)(nil),                                       // 19: api.gamification.service.v1.ClaimRule
-	(v1.RuleStatus)(0),                                         // 20: api.gamification.service.v1.RuleStatus
-	(*v1.GameRestrictionRule)(nil),                             // 21: api.gamification.service.v1.GameRestrictionRule
-	(*v1.CreateClaimRuleResponse)(nil),                         // 22: api.gamification.service.v1.CreateClaimRuleResponse
-	(*v1.UpdateClaimRuleResponse)(nil),                         // 23: api.gamification.service.v1.UpdateClaimRuleResponse
-	(*v1.DeleteClaimRuleResponse)(nil),                         // 24: api.gamification.service.v1.DeleteClaimRuleResponse
-	(*v1.ListClaimRulesResponse)(nil),                          // 25: api.gamification.service.v1.ListClaimRulesResponse
-	(*v1.GetClaimRuleResponse)(nil),                            // 26: api.gamification.service.v1.GetClaimRuleResponse
-	(*v1.UpdateClaimRulePriorityResponse)(nil),                 // 27: api.gamification.service.v1.UpdateClaimRulePriorityResponse
-	(*v1.UpdateClaimRuleStatusResponse)(nil),                   // 28: api.gamification.service.v1.UpdateClaimRuleStatusResponse
-	(*v1.CreateGameRestrictionRuleResponse)(nil),               // 29: api.gamification.service.v1.CreateGameRestrictionRuleResponse
-	(*v1.UpdateGameRestrictionRuleResponse)(nil),               // 30: api.gamification.service.v1.UpdateGameRestrictionRuleResponse
-	(*v1.DeleteGameRestrictionRuleResponse)(nil),               // 31: api.gamification.service.v1.DeleteGameRestrictionRuleResponse
-	(*v1.ListGameRestrictionRulesResponse)(nil),                // 32: api.gamification.service.v1.ListGameRestrictionRulesResponse
-	(*v1.GetGameRestrictionRuleResponse)(nil),                  // 33: api.gamification.service.v1.GetGameRestrictionRuleResponse
-	(*v1.UpdateGameRestrictionRulePriorityResponse)(nil),       // 34: api.gamification.service.v1.UpdateGameRestrictionRulePriorityResponse
-	(*v1.UpdateGameRestrictionRuleStatusResponse)(nil),         // 35: api.gamification.service.v1.UpdateGameRestrictionRuleStatusResponse
-	(*v1.GetBonusBuyConfigResponse)(nil),                       // 36: api.gamification.service.v1.GetBonusBuyConfigResponse
-	(*v1.UpdateBonusBuyConfigResponse)(nil),                    // 37: api.gamification.service.v1.UpdateBonusBuyConfigResponse
-	(*v1.GetRuleHierarchyConfigResponse)(nil),                  // 38: api.gamification.service.v1.GetRuleHierarchyConfigResponse
-	(*v1.UpdateRuleHierarchyConfigResponse)(nil),               // 39: api.gamification.service.v1.UpdateRuleHierarchyConfigResponse
+	(*BackofficeCreateClaimRuleRequest)(nil),                     // 0: api.backoffice.service.v1.BackofficeCreateClaimRuleRequest
+	(*BackofficeUpdateClaimRuleRequest)(nil),                     // 1: api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest
+	(*BackofficeDeleteClaimRuleRequest)(nil),                     // 2: api.backoffice.service.v1.BackofficeDeleteClaimRuleRequest
+	(*BackofficeListClaimRulesRequest)(nil),                      // 3: api.backoffice.service.v1.BackofficeListClaimRulesRequest
+	(*BackofficeListClaimRulesResponse)(nil),                     // 4: api.backoffice.service.v1.BackofficeListClaimRulesResponse
+	(*BackofficeGetClaimRuleRequest)(nil),                        // 5: api.backoffice.service.v1.BackofficeGetClaimRuleRequest
+	(*BackofficeUpdateClaimRulePriorityRequest)(nil),             // 6: api.backoffice.service.v1.BackofficeUpdateClaimRulePriorityRequest
+	(*BackofficeUpdateClaimRuleStatusRequest)(nil),               // 7: api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest
+	(*BackofficeSetClaimRuleFollowParentRequest)(nil),            // 8: api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentRequest
+	(*BackofficeSetClaimRuleFollowParentResponse)(nil),           // 9: api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentResponse
+	(*BackofficeCreateGameRestrictionRuleRequest)(nil),           // 10: api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest
+	(*BackofficeUpdateGameRestrictionRuleRequest)(nil),           // 11: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest
+	(*BackofficeDeleteGameRestrictionRuleRequest)(nil),           // 12: api.backoffice.service.v1.BackofficeDeleteGameRestrictionRuleRequest
+	(*BackofficeListGameRestrictionRulesRequest)(nil),            // 13: api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest
+	(*BackofficeListGameRestrictionRulesResponse)(nil),           // 14: api.backoffice.service.v1.BackofficeListGameRestrictionRulesResponse
+	(*BackofficeGetGameRestrictionRuleRequest)(nil),              // 15: api.backoffice.service.v1.BackofficeGetGameRestrictionRuleRequest
+	(*BackofficeUpdateGameRestrictionRulePriorityRequest)(nil),   // 16: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRulePriorityRequest
+	(*BackofficeUpdateGameRestrictionRuleStatusRequest)(nil),     // 17: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest
+	(*BackofficeSetGameRestrictionRuleFollowParentRequest)(nil),  // 18: api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentRequest
+	(*BackofficeSetGameRestrictionRuleFollowParentResponse)(nil), // 19: api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentResponse
+	(*BackofficeGetBonusBuyConfigRequest)(nil),                   // 20: api.backoffice.service.v1.BackofficeGetBonusBuyConfigRequest
+	(*BackofficeUpdateBonusBuyConfigRequest)(nil),                // 21: api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest
+	(*common.OperatorContext)(nil),                               // 22: api.common.OperatorContext
+	(*v1.ClaimRule)(nil),                                         // 23: api.gamification.service.v1.ClaimRule
+	(v1.RuleStatus)(0),                                           // 24: api.gamification.service.v1.RuleStatus
+	(*v1.GameRestrictionRule)(nil),                               // 25: api.gamification.service.v1.GameRestrictionRule
+	(*v1.CreateClaimRuleResponse)(nil),                           // 26: api.gamification.service.v1.CreateClaimRuleResponse
+	(*v1.UpdateClaimRuleResponse)(nil),                           // 27: api.gamification.service.v1.UpdateClaimRuleResponse
+	(*v1.DeleteClaimRuleResponse)(nil),                           // 28: api.gamification.service.v1.DeleteClaimRuleResponse
+	(*v1.GetClaimRuleResponse)(nil),                              // 29: api.gamification.service.v1.GetClaimRuleResponse
+	(*v1.UpdateClaimRulePriorityResponse)(nil),                   // 30: api.gamification.service.v1.UpdateClaimRulePriorityResponse
+	(*v1.UpdateClaimRuleStatusResponse)(nil),                     // 31: api.gamification.service.v1.UpdateClaimRuleStatusResponse
+	(*v1.CreateGameRestrictionRuleResponse)(nil),                 // 32: api.gamification.service.v1.CreateGameRestrictionRuleResponse
+	(*v1.UpdateGameRestrictionRuleResponse)(nil),                 // 33: api.gamification.service.v1.UpdateGameRestrictionRuleResponse
+	(*v1.DeleteGameRestrictionRuleResponse)(nil),                 // 34: api.gamification.service.v1.DeleteGameRestrictionRuleResponse
+	(*v1.GetGameRestrictionRuleResponse)(nil),                    // 35: api.gamification.service.v1.GetGameRestrictionRuleResponse
+	(*v1.UpdateGameRestrictionRulePriorityResponse)(nil),         // 36: api.gamification.service.v1.UpdateGameRestrictionRulePriorityResponse
+	(*v1.UpdateGameRestrictionRuleStatusResponse)(nil),           // 37: api.gamification.service.v1.UpdateGameRestrictionRuleStatusResponse
+	(*v1.GetBonusBuyConfigResponse)(nil),                         // 38: api.gamification.service.v1.GetBonusBuyConfigResponse
+	(*v1.UpdateBonusBuyConfigResponse)(nil),                      // 39: api.gamification.service.v1.UpdateBonusBuyConfigResponse
 }
 var file_backoffice_service_v1_backoffice_gamification_proto_depIdxs = []int32{
-	18, // 0: api.backoffice.service.v1.BackofficeCreateClaimRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
-	19, // 1: api.backoffice.service.v1.BackofficeCreateClaimRuleRequest.rule:type_name -> api.gamification.service.v1.ClaimRule
-	18, // 2: api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
-	19, // 3: api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest.rule:type_name -> api.gamification.service.v1.ClaimRule
-	18, // 4: api.backoffice.service.v1.BackofficeDeleteClaimRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 5: api.backoffice.service.v1.BackofficeListClaimRulesRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 6: api.backoffice.service.v1.BackofficeGetClaimRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 7: api.backoffice.service.v1.BackofficeUpdateClaimRulePriorityRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 8: api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest.target_operator_context:type_name -> api.common.OperatorContext
-	20, // 9: api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest.status:type_name -> api.gamification.service.v1.RuleStatus
-	18, // 10: api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
-	21, // 11: api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest.rule:type_name -> api.gamification.service.v1.GameRestrictionRule
-	18, // 12: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
-	21, // 13: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest.rule:type_name -> api.gamification.service.v1.GameRestrictionRule
-	18, // 14: api.backoffice.service.v1.BackofficeDeleteGameRestrictionRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 15: api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 16: api.backoffice.service.v1.BackofficeGetGameRestrictionRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 17: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRulePriorityRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 18: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest.target_operator_context:type_name -> api.common.OperatorContext
-	20, // 19: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest.status:type_name -> api.gamification.service.v1.RuleStatus
-	18, // 20: api.backoffice.service.v1.BackofficeGetBonusBuyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 21: api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 22: api.backoffice.service.v1.BackofficeGetRuleHierarchyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	18, // 23: api.backoffice.service.v1.BackofficeUpdateRuleHierarchyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
-	0,  // 24: api.backoffice.service.v1.BackofficeGamification.CreateClaimRule:input_type -> api.backoffice.service.v1.BackofficeCreateClaimRuleRequest
-	1,  // 25: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRule:input_type -> api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest
-	2,  // 26: api.backoffice.service.v1.BackofficeGamification.DeleteClaimRule:input_type -> api.backoffice.service.v1.BackofficeDeleteClaimRuleRequest
-	3,  // 27: api.backoffice.service.v1.BackofficeGamification.ListClaimRules:input_type -> api.backoffice.service.v1.BackofficeListClaimRulesRequest
-	4,  // 28: api.backoffice.service.v1.BackofficeGamification.GetClaimRule:input_type -> api.backoffice.service.v1.BackofficeGetClaimRuleRequest
-	5,  // 29: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRulePriority:input_type -> api.backoffice.service.v1.BackofficeUpdateClaimRulePriorityRequest
-	6,  // 30: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRuleStatus:input_type -> api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest
-	7,  // 31: api.backoffice.service.v1.BackofficeGamification.CreateGameRestrictionRule:input_type -> api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest
-	8,  // 32: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRule:input_type -> api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest
-	9,  // 33: api.backoffice.service.v1.BackofficeGamification.DeleteGameRestrictionRule:input_type -> api.backoffice.service.v1.BackofficeDeleteGameRestrictionRuleRequest
-	10, // 34: api.backoffice.service.v1.BackofficeGamification.ListGameRestrictionRules:input_type -> api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest
-	11, // 35: api.backoffice.service.v1.BackofficeGamification.GetGameRestrictionRule:input_type -> api.backoffice.service.v1.BackofficeGetGameRestrictionRuleRequest
-	12, // 36: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRulePriority:input_type -> api.backoffice.service.v1.BackofficeUpdateGameRestrictionRulePriorityRequest
-	13, // 37: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRuleStatus:input_type -> api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest
-	14, // 38: api.backoffice.service.v1.BackofficeGamification.GetBonusBuyConfig:input_type -> api.backoffice.service.v1.BackofficeGetBonusBuyConfigRequest
-	15, // 39: api.backoffice.service.v1.BackofficeGamification.UpdateBonusBuyConfig:input_type -> api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest
-	16, // 40: api.backoffice.service.v1.BackofficeGamification.GetRuleHierarchyConfig:input_type -> api.backoffice.service.v1.BackofficeGetRuleHierarchyConfigRequest
-	17, // 41: api.backoffice.service.v1.BackofficeGamification.UpdateRuleHierarchyConfig:input_type -> api.backoffice.service.v1.BackofficeUpdateRuleHierarchyConfigRequest
-	22, // 42: api.backoffice.service.v1.BackofficeGamification.CreateClaimRule:output_type -> api.gamification.service.v1.CreateClaimRuleResponse
-	23, // 43: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRule:output_type -> api.gamification.service.v1.UpdateClaimRuleResponse
-	24, // 44: api.backoffice.service.v1.BackofficeGamification.DeleteClaimRule:output_type -> api.gamification.service.v1.DeleteClaimRuleResponse
-	25, // 45: api.backoffice.service.v1.BackofficeGamification.ListClaimRules:output_type -> api.gamification.service.v1.ListClaimRulesResponse
-	26, // 46: api.backoffice.service.v1.BackofficeGamification.GetClaimRule:output_type -> api.gamification.service.v1.GetClaimRuleResponse
-	27, // 47: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRulePriority:output_type -> api.gamification.service.v1.UpdateClaimRulePriorityResponse
-	28, // 48: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRuleStatus:output_type -> api.gamification.service.v1.UpdateClaimRuleStatusResponse
-	29, // 49: api.backoffice.service.v1.BackofficeGamification.CreateGameRestrictionRule:output_type -> api.gamification.service.v1.CreateGameRestrictionRuleResponse
-	30, // 50: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRule:output_type -> api.gamification.service.v1.UpdateGameRestrictionRuleResponse
-	31, // 51: api.backoffice.service.v1.BackofficeGamification.DeleteGameRestrictionRule:output_type -> api.gamification.service.v1.DeleteGameRestrictionRuleResponse
-	32, // 52: api.backoffice.service.v1.BackofficeGamification.ListGameRestrictionRules:output_type -> api.gamification.service.v1.ListGameRestrictionRulesResponse
-	33, // 53: api.backoffice.service.v1.BackofficeGamification.GetGameRestrictionRule:output_type -> api.gamification.service.v1.GetGameRestrictionRuleResponse
-	34, // 54: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRulePriority:output_type -> api.gamification.service.v1.UpdateGameRestrictionRulePriorityResponse
-	35, // 55: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRuleStatus:output_type -> api.gamification.service.v1.UpdateGameRestrictionRuleStatusResponse
-	36, // 56: api.backoffice.service.v1.BackofficeGamification.GetBonusBuyConfig:output_type -> api.gamification.service.v1.GetBonusBuyConfigResponse
-	37, // 57: api.backoffice.service.v1.BackofficeGamification.UpdateBonusBuyConfig:output_type -> api.gamification.service.v1.UpdateBonusBuyConfigResponse
-	38, // 58: api.backoffice.service.v1.BackofficeGamification.GetRuleHierarchyConfig:output_type -> api.gamification.service.v1.GetRuleHierarchyConfigResponse
-	39, // 59: api.backoffice.service.v1.BackofficeGamification.UpdateRuleHierarchyConfig:output_type -> api.gamification.service.v1.UpdateRuleHierarchyConfigResponse
-	42, // [42:60] is the sub-list for method output_type
-	24, // [24:42] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	22, // 0: api.backoffice.service.v1.BackofficeCreateClaimRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
+	23, // 1: api.backoffice.service.v1.BackofficeCreateClaimRuleRequest.rule:type_name -> api.gamification.service.v1.ClaimRule
+	22, // 2: api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
+	23, // 3: api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest.rule:type_name -> api.gamification.service.v1.ClaimRule
+	22, // 4: api.backoffice.service.v1.BackofficeDeleteClaimRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 5: api.backoffice.service.v1.BackofficeListClaimRulesRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 6: api.backoffice.service.v1.BackofficeListClaimRulesResponse.custom_operator_context:type_name -> api.common.OperatorContext
+	23, // 7: api.backoffice.service.v1.BackofficeListClaimRulesResponse.rules:type_name -> api.gamification.service.v1.ClaimRule
+	22, // 8: api.backoffice.service.v1.BackofficeGetClaimRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 9: api.backoffice.service.v1.BackofficeUpdateClaimRulePriorityRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 10: api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest.target_operator_context:type_name -> api.common.OperatorContext
+	24, // 11: api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest.status:type_name -> api.gamification.service.v1.RuleStatus
+	22, // 12: api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 13: api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
+	25, // 14: api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest.rule:type_name -> api.gamification.service.v1.GameRestrictionRule
+	22, // 15: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
+	25, // 16: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest.rule:type_name -> api.gamification.service.v1.GameRestrictionRule
+	22, // 17: api.backoffice.service.v1.BackofficeDeleteGameRestrictionRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 18: api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 19: api.backoffice.service.v1.BackofficeListGameRestrictionRulesResponse.custom_operator_context:type_name -> api.common.OperatorContext
+	25, // 20: api.backoffice.service.v1.BackofficeListGameRestrictionRulesResponse.rules:type_name -> api.gamification.service.v1.GameRestrictionRule
+	22, // 21: api.backoffice.service.v1.BackofficeGetGameRestrictionRuleRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 22: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRulePriorityRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 23: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest.target_operator_context:type_name -> api.common.OperatorContext
+	24, // 24: api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest.status:type_name -> api.gamification.service.v1.RuleStatus
+	22, // 25: api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 26: api.backoffice.service.v1.BackofficeGetBonusBuyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	22, // 27: api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest.target_operator_context:type_name -> api.common.OperatorContext
+	0,  // 28: api.backoffice.service.v1.BackofficeGamification.CreateClaimRule:input_type -> api.backoffice.service.v1.BackofficeCreateClaimRuleRequest
+	1,  // 29: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRule:input_type -> api.backoffice.service.v1.BackofficeUpdateClaimRuleRequest
+	2,  // 30: api.backoffice.service.v1.BackofficeGamification.DeleteClaimRule:input_type -> api.backoffice.service.v1.BackofficeDeleteClaimRuleRequest
+	3,  // 31: api.backoffice.service.v1.BackofficeGamification.ListClaimRules:input_type -> api.backoffice.service.v1.BackofficeListClaimRulesRequest
+	5,  // 32: api.backoffice.service.v1.BackofficeGamification.GetClaimRule:input_type -> api.backoffice.service.v1.BackofficeGetClaimRuleRequest
+	6,  // 33: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRulePriority:input_type -> api.backoffice.service.v1.BackofficeUpdateClaimRulePriorityRequest
+	7,  // 34: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRuleStatus:input_type -> api.backoffice.service.v1.BackofficeUpdateClaimRuleStatusRequest
+	8,  // 35: api.backoffice.service.v1.BackofficeGamification.SetClaimRuleFollowParent:input_type -> api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentRequest
+	10, // 36: api.backoffice.service.v1.BackofficeGamification.CreateGameRestrictionRule:input_type -> api.backoffice.service.v1.BackofficeCreateGameRestrictionRuleRequest
+	11, // 37: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRule:input_type -> api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleRequest
+	12, // 38: api.backoffice.service.v1.BackofficeGamification.DeleteGameRestrictionRule:input_type -> api.backoffice.service.v1.BackofficeDeleteGameRestrictionRuleRequest
+	13, // 39: api.backoffice.service.v1.BackofficeGamification.ListGameRestrictionRules:input_type -> api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest
+	15, // 40: api.backoffice.service.v1.BackofficeGamification.GetGameRestrictionRule:input_type -> api.backoffice.service.v1.BackofficeGetGameRestrictionRuleRequest
+	16, // 41: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRulePriority:input_type -> api.backoffice.service.v1.BackofficeUpdateGameRestrictionRulePriorityRequest
+	17, // 42: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRuleStatus:input_type -> api.backoffice.service.v1.BackofficeUpdateGameRestrictionRuleStatusRequest
+	18, // 43: api.backoffice.service.v1.BackofficeGamification.SetGameRestrictionRuleFollowParent:input_type -> api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentRequest
+	20, // 44: api.backoffice.service.v1.BackofficeGamification.GetBonusBuyConfig:input_type -> api.backoffice.service.v1.BackofficeGetBonusBuyConfigRequest
+	21, // 45: api.backoffice.service.v1.BackofficeGamification.UpdateBonusBuyConfig:input_type -> api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest
+	26, // 46: api.backoffice.service.v1.BackofficeGamification.CreateClaimRule:output_type -> api.gamification.service.v1.CreateClaimRuleResponse
+	27, // 47: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRule:output_type -> api.gamification.service.v1.UpdateClaimRuleResponse
+	28, // 48: api.backoffice.service.v1.BackofficeGamification.DeleteClaimRule:output_type -> api.gamification.service.v1.DeleteClaimRuleResponse
+	4,  // 49: api.backoffice.service.v1.BackofficeGamification.ListClaimRules:output_type -> api.backoffice.service.v1.BackofficeListClaimRulesResponse
+	29, // 50: api.backoffice.service.v1.BackofficeGamification.GetClaimRule:output_type -> api.gamification.service.v1.GetClaimRuleResponse
+	30, // 51: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRulePriority:output_type -> api.gamification.service.v1.UpdateClaimRulePriorityResponse
+	31, // 52: api.backoffice.service.v1.BackofficeGamification.UpdateClaimRuleStatus:output_type -> api.gamification.service.v1.UpdateClaimRuleStatusResponse
+	9,  // 53: api.backoffice.service.v1.BackofficeGamification.SetClaimRuleFollowParent:output_type -> api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentResponse
+	32, // 54: api.backoffice.service.v1.BackofficeGamification.CreateGameRestrictionRule:output_type -> api.gamification.service.v1.CreateGameRestrictionRuleResponse
+	33, // 55: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRule:output_type -> api.gamification.service.v1.UpdateGameRestrictionRuleResponse
+	34, // 56: api.backoffice.service.v1.BackofficeGamification.DeleteGameRestrictionRule:output_type -> api.gamification.service.v1.DeleteGameRestrictionRuleResponse
+	14, // 57: api.backoffice.service.v1.BackofficeGamification.ListGameRestrictionRules:output_type -> api.backoffice.service.v1.BackofficeListGameRestrictionRulesResponse
+	35, // 58: api.backoffice.service.v1.BackofficeGamification.GetGameRestrictionRule:output_type -> api.gamification.service.v1.GetGameRestrictionRuleResponse
+	36, // 59: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRulePriority:output_type -> api.gamification.service.v1.UpdateGameRestrictionRulePriorityResponse
+	37, // 60: api.backoffice.service.v1.BackofficeGamification.UpdateGameRestrictionRuleStatus:output_type -> api.gamification.service.v1.UpdateGameRestrictionRuleStatusResponse
+	19, // 61: api.backoffice.service.v1.BackofficeGamification.SetGameRestrictionRuleFollowParent:output_type -> api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentResponse
+	38, // 62: api.backoffice.service.v1.BackofficeGamification.GetBonusBuyConfig:output_type -> api.gamification.service.v1.GetBonusBuyConfigResponse
+	39, // 63: api.backoffice.service.v1.BackofficeGamification.UpdateBonusBuyConfig:output_type -> api.gamification.service.v1.UpdateBonusBuyConfigResponse
+	46, // [46:64] is the sub-list for method output_type
+	28, // [28:46] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_backoffice_service_v1_backoffice_gamification_proto_init() }
@@ -1230,7 +1483,7 @@ func file_backoffice_service_v1_backoffice_gamification_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_backoffice_service_v1_backoffice_gamification_proto_rawDesc), len(file_backoffice_service_v1_backoffice_gamification_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/backoffice/service/v1/backoffice_gamification.pb.validate.go
+++ b/backoffice/service/v1/backoffice_gamification.pb.validate.go
@@ -637,6 +637,182 @@ var _ interface {
 	ErrorName() string
 } = BackofficeListClaimRulesRequestValidationError{}
 
+// Validate checks the field values on BackofficeListClaimRulesResponse with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the first error encountered is returned, or nil if there are
+// no violations.
+func (m *BackofficeListClaimRulesResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on BackofficeListClaimRulesResponse with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// BackofficeListClaimRulesResponseMultiError, or nil if none found.
+func (m *BackofficeListClaimRulesResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *BackofficeListClaimRulesResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetCustomOperatorContext()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, BackofficeListClaimRulesResponseValidationError{
+					field:  "CustomOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, BackofficeListClaimRulesResponseValidationError{
+					field:  "CustomOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetCustomOperatorContext()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return BackofficeListClaimRulesResponseValidationError{
+				field:  "CustomOperatorContext",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for FollowParent
+
+	for idx, item := range m.GetRules() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, BackofficeListClaimRulesResponseValidationError{
+						field:  fmt.Sprintf("Rules[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, BackofficeListClaimRulesResponseValidationError{
+						field:  fmt.Sprintf("Rules[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return BackofficeListClaimRulesResponseValidationError{
+					field:  fmt.Sprintf("Rules[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	// no validation rules for Total
+
+	// no validation rules for Page
+
+	// no validation rules for PageSize
+
+	if len(errors) > 0 {
+		return BackofficeListClaimRulesResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// BackofficeListClaimRulesResponseMultiError is an error wrapping multiple
+// validation errors returned by
+// BackofficeListClaimRulesResponse.ValidateAll() if the designated
+// constraints aren't met.
+type BackofficeListClaimRulesResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m BackofficeListClaimRulesResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m BackofficeListClaimRulesResponseMultiError) AllErrors() []error { return m }
+
+// BackofficeListClaimRulesResponseValidationError is the validation error
+// returned by BackofficeListClaimRulesResponse.Validate if the designated
+// constraints aren't met.
+type BackofficeListClaimRulesResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e BackofficeListClaimRulesResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e BackofficeListClaimRulesResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e BackofficeListClaimRulesResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e BackofficeListClaimRulesResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e BackofficeListClaimRulesResponseValidationError) ErrorName() string {
+	return "BackofficeListClaimRulesResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e BackofficeListClaimRulesResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sBackofficeListClaimRulesResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = BackofficeListClaimRulesResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = BackofficeListClaimRulesResponseValidationError{}
+
 // Validate checks the field values on BackofficeGetClaimRuleRequest with the
 // rules defined in the proto definition for this message. If any rules are
 // violated, the first error encountered is returned, or nil if there are no violations.
@@ -1048,6 +1224,249 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = BackofficeUpdateClaimRuleStatusRequestValidationError{}
+
+// Validate checks the field values on
+// BackofficeSetClaimRuleFollowParentRequest with the rules defined in the
+// proto definition for this message. If any rules are violated, the first
+// error encountered is returned, or nil if there are no violations.
+func (m *BackofficeSetClaimRuleFollowParentRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on
+// BackofficeSetClaimRuleFollowParentRequest with the rules defined in the
+// proto definition for this message. If any rules are violated, the result is
+// a list of violation errors wrapped in
+// BackofficeSetClaimRuleFollowParentRequestMultiError, or nil if none found.
+func (m *BackofficeSetClaimRuleFollowParentRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *BackofficeSetClaimRuleFollowParentRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetTargetOperatorContext()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, BackofficeSetClaimRuleFollowParentRequestValidationError{
+					field:  "TargetOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, BackofficeSetClaimRuleFollowParentRequestValidationError{
+					field:  "TargetOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetTargetOperatorContext()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return BackofficeSetClaimRuleFollowParentRequestValidationError{
+				field:  "TargetOperatorContext",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for FollowParent
+
+	if len(errors) > 0 {
+		return BackofficeSetClaimRuleFollowParentRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// BackofficeSetClaimRuleFollowParentRequestMultiError is an error wrapping
+// multiple validation errors returned by
+// BackofficeSetClaimRuleFollowParentRequest.ValidateAll() if the designated
+// constraints aren't met.
+type BackofficeSetClaimRuleFollowParentRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m BackofficeSetClaimRuleFollowParentRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m BackofficeSetClaimRuleFollowParentRequestMultiError) AllErrors() []error { return m }
+
+// BackofficeSetClaimRuleFollowParentRequestValidationError is the validation
+// error returned by BackofficeSetClaimRuleFollowParentRequest.Validate if the
+// designated constraints aren't met.
+type BackofficeSetClaimRuleFollowParentRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e BackofficeSetClaimRuleFollowParentRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e BackofficeSetClaimRuleFollowParentRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e BackofficeSetClaimRuleFollowParentRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e BackofficeSetClaimRuleFollowParentRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e BackofficeSetClaimRuleFollowParentRequestValidationError) ErrorName() string {
+	return "BackofficeSetClaimRuleFollowParentRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e BackofficeSetClaimRuleFollowParentRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sBackofficeSetClaimRuleFollowParentRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = BackofficeSetClaimRuleFollowParentRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = BackofficeSetClaimRuleFollowParentRequestValidationError{}
+
+// Validate checks the field values on
+// BackofficeSetClaimRuleFollowParentResponse with the rules defined in the
+// proto definition for this message. If any rules are violated, the first
+// error encountered is returned, or nil if there are no violations.
+func (m *BackofficeSetClaimRuleFollowParentResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on
+// BackofficeSetClaimRuleFollowParentResponse with the rules defined in the
+// proto definition for this message. If any rules are violated, the result is
+// a list of violation errors wrapped in
+// BackofficeSetClaimRuleFollowParentResponseMultiError, or nil if none found.
+func (m *BackofficeSetClaimRuleFollowParentResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *BackofficeSetClaimRuleFollowParentResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return BackofficeSetClaimRuleFollowParentResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// BackofficeSetClaimRuleFollowParentResponseMultiError is an error wrapping
+// multiple validation errors returned by
+// BackofficeSetClaimRuleFollowParentResponse.ValidateAll() if the designated
+// constraints aren't met.
+type BackofficeSetClaimRuleFollowParentResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m BackofficeSetClaimRuleFollowParentResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m BackofficeSetClaimRuleFollowParentResponseMultiError) AllErrors() []error { return m }
+
+// BackofficeSetClaimRuleFollowParentResponseValidationError is the validation
+// error returned by BackofficeSetClaimRuleFollowParentResponse.Validate if
+// the designated constraints aren't met.
+type BackofficeSetClaimRuleFollowParentResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e BackofficeSetClaimRuleFollowParentResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e BackofficeSetClaimRuleFollowParentResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e BackofficeSetClaimRuleFollowParentResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e BackofficeSetClaimRuleFollowParentResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e BackofficeSetClaimRuleFollowParentResponseValidationError) ErrorName() string {
+	return "BackofficeSetClaimRuleFollowParentResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e BackofficeSetClaimRuleFollowParentResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sBackofficeSetClaimRuleFollowParentResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = BackofficeSetClaimRuleFollowParentResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = BackofficeSetClaimRuleFollowParentResponseValidationError{}
 
 // Validate checks the field values on
 // BackofficeCreateGameRestrictionRuleRequest with the rules defined in the
@@ -1653,6 +2072,183 @@ var _ interface {
 	ErrorName() string
 } = BackofficeListGameRestrictionRulesRequestValidationError{}
 
+// Validate checks the field values on
+// BackofficeListGameRestrictionRulesResponse with the rules defined in the
+// proto definition for this message. If any rules are violated, the first
+// error encountered is returned, or nil if there are no violations.
+func (m *BackofficeListGameRestrictionRulesResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on
+// BackofficeListGameRestrictionRulesResponse with the rules defined in the
+// proto definition for this message. If any rules are violated, the result is
+// a list of violation errors wrapped in
+// BackofficeListGameRestrictionRulesResponseMultiError, or nil if none found.
+func (m *BackofficeListGameRestrictionRulesResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *BackofficeListGameRestrictionRulesResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetCustomOperatorContext()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, BackofficeListGameRestrictionRulesResponseValidationError{
+					field:  "CustomOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, BackofficeListGameRestrictionRulesResponseValidationError{
+					field:  "CustomOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetCustomOperatorContext()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return BackofficeListGameRestrictionRulesResponseValidationError{
+				field:  "CustomOperatorContext",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for FollowParent
+
+	for idx, item := range m.GetRules() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, BackofficeListGameRestrictionRulesResponseValidationError{
+						field:  fmt.Sprintf("Rules[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, BackofficeListGameRestrictionRulesResponseValidationError{
+						field:  fmt.Sprintf("Rules[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return BackofficeListGameRestrictionRulesResponseValidationError{
+					field:  fmt.Sprintf("Rules[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	// no validation rules for Total
+
+	// no validation rules for Page
+
+	// no validation rules for PageSize
+
+	if len(errors) > 0 {
+		return BackofficeListGameRestrictionRulesResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// BackofficeListGameRestrictionRulesResponseMultiError is an error wrapping
+// multiple validation errors returned by
+// BackofficeListGameRestrictionRulesResponse.ValidateAll() if the designated
+// constraints aren't met.
+type BackofficeListGameRestrictionRulesResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m BackofficeListGameRestrictionRulesResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m BackofficeListGameRestrictionRulesResponseMultiError) AllErrors() []error { return m }
+
+// BackofficeListGameRestrictionRulesResponseValidationError is the validation
+// error returned by BackofficeListGameRestrictionRulesResponse.Validate if
+// the designated constraints aren't met.
+type BackofficeListGameRestrictionRulesResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e BackofficeListGameRestrictionRulesResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e BackofficeListGameRestrictionRulesResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e BackofficeListGameRestrictionRulesResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e BackofficeListGameRestrictionRulesResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e BackofficeListGameRestrictionRulesResponseValidationError) ErrorName() string {
+	return "BackofficeListGameRestrictionRulesResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e BackofficeListGameRestrictionRulesResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sBackofficeListGameRestrictionRulesResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = BackofficeListGameRestrictionRulesResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = BackofficeListGameRestrictionRulesResponseValidationError{}
+
 // Validate checks the field values on BackofficeGetGameRestrictionRuleRequest
 // with the rules defined in the proto definition for this message. If any
 // rules are violated, the first error encountered is returned, or nil if
@@ -2083,6 +2679,265 @@ var _ interface {
 	ErrorName() string
 } = BackofficeUpdateGameRestrictionRuleStatusRequestValidationError{}
 
+// Validate checks the field values on
+// BackofficeSetGameRestrictionRuleFollowParentRequest with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *BackofficeSetGameRestrictionRuleFollowParentRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on
+// BackofficeSetGameRestrictionRuleFollowParentRequest with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// result is a list of violation errors wrapped in
+// BackofficeSetGameRestrictionRuleFollowParentRequestMultiError, or nil if
+// none found.
+func (m *BackofficeSetGameRestrictionRuleFollowParentRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *BackofficeSetGameRestrictionRuleFollowParentRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetTargetOperatorContext()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, BackofficeSetGameRestrictionRuleFollowParentRequestValidationError{
+					field:  "TargetOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, BackofficeSetGameRestrictionRuleFollowParentRequestValidationError{
+					field:  "TargetOperatorContext",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetTargetOperatorContext()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return BackofficeSetGameRestrictionRuleFollowParentRequestValidationError{
+				field:  "TargetOperatorContext",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for FollowParent
+
+	if len(errors) > 0 {
+		return BackofficeSetGameRestrictionRuleFollowParentRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// BackofficeSetGameRestrictionRuleFollowParentRequestMultiError is an error
+// wrapping multiple validation errors returned by
+// BackofficeSetGameRestrictionRuleFollowParentRequest.ValidateAll() if the
+// designated constraints aren't met.
+type BackofficeSetGameRestrictionRuleFollowParentRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m BackofficeSetGameRestrictionRuleFollowParentRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m BackofficeSetGameRestrictionRuleFollowParentRequestMultiError) AllErrors() []error { return m }
+
+// BackofficeSetGameRestrictionRuleFollowParentRequestValidationError is the
+// validation error returned by
+// BackofficeSetGameRestrictionRuleFollowParentRequest.Validate if the
+// designated constraints aren't met.
+type BackofficeSetGameRestrictionRuleFollowParentRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e BackofficeSetGameRestrictionRuleFollowParentRequestValidationError) Field() string {
+	return e.field
+}
+
+// Reason function returns reason value.
+func (e BackofficeSetGameRestrictionRuleFollowParentRequestValidationError) Reason() string {
+	return e.reason
+}
+
+// Cause function returns cause value.
+func (e BackofficeSetGameRestrictionRuleFollowParentRequestValidationError) Cause() error {
+	return e.cause
+}
+
+// Key function returns key value.
+func (e BackofficeSetGameRestrictionRuleFollowParentRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e BackofficeSetGameRestrictionRuleFollowParentRequestValidationError) ErrorName() string {
+	return "BackofficeSetGameRestrictionRuleFollowParentRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e BackofficeSetGameRestrictionRuleFollowParentRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sBackofficeSetGameRestrictionRuleFollowParentRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = BackofficeSetGameRestrictionRuleFollowParentRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = BackofficeSetGameRestrictionRuleFollowParentRequestValidationError{}
+
+// Validate checks the field values on
+// BackofficeSetGameRestrictionRuleFollowParentResponse with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *BackofficeSetGameRestrictionRuleFollowParentResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on
+// BackofficeSetGameRestrictionRuleFollowParentResponse with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// result is a list of violation errors wrapped in
+// BackofficeSetGameRestrictionRuleFollowParentResponseMultiError, or nil if
+// none found.
+func (m *BackofficeSetGameRestrictionRuleFollowParentResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *BackofficeSetGameRestrictionRuleFollowParentResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return BackofficeSetGameRestrictionRuleFollowParentResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// BackofficeSetGameRestrictionRuleFollowParentResponseMultiError is an error
+// wrapping multiple validation errors returned by
+// BackofficeSetGameRestrictionRuleFollowParentResponse.ValidateAll() if the
+// designated constraints aren't met.
+type BackofficeSetGameRestrictionRuleFollowParentResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m BackofficeSetGameRestrictionRuleFollowParentResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m BackofficeSetGameRestrictionRuleFollowParentResponseMultiError) AllErrors() []error { return m }
+
+// BackofficeSetGameRestrictionRuleFollowParentResponseValidationError is the
+// validation error returned by
+// BackofficeSetGameRestrictionRuleFollowParentResponse.Validate if the
+// designated constraints aren't met.
+type BackofficeSetGameRestrictionRuleFollowParentResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e BackofficeSetGameRestrictionRuleFollowParentResponseValidationError) Field() string {
+	return e.field
+}
+
+// Reason function returns reason value.
+func (e BackofficeSetGameRestrictionRuleFollowParentResponseValidationError) Reason() string {
+	return e.reason
+}
+
+// Cause function returns cause value.
+func (e BackofficeSetGameRestrictionRuleFollowParentResponseValidationError) Cause() error {
+	return e.cause
+}
+
+// Key function returns key value.
+func (e BackofficeSetGameRestrictionRuleFollowParentResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e BackofficeSetGameRestrictionRuleFollowParentResponseValidationError) ErrorName() string {
+	return "BackofficeSetGameRestrictionRuleFollowParentResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e BackofficeSetGameRestrictionRuleFollowParentResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sBackofficeSetGameRestrictionRuleFollowParentResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = BackofficeSetGameRestrictionRuleFollowParentResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = BackofficeSetGameRestrictionRuleFollowParentResponseValidationError{}
+
 // Validate checks the field values on BackofficeGetBonusBuyConfigRequest with
 // the rules defined in the proto definition for this message. If any rules
 // are violated, the first error encountered is returned, or nil if there are
@@ -2352,279 +3207,3 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = BackofficeUpdateBonusBuyConfigRequestValidationError{}
-
-// Validate checks the field values on BackofficeGetRuleHierarchyConfigRequest
-// with the rules defined in the proto definition for this message. If any
-// rules are violated, the first error encountered is returned, or nil if
-// there are no violations.
-func (m *BackofficeGetRuleHierarchyConfigRequest) Validate() error {
-	return m.validate(false)
-}
-
-// ValidateAll checks the field values on
-// BackofficeGetRuleHierarchyConfigRequest with the rules defined in the proto
-// definition for this message. If any rules are violated, the result is a
-// list of violation errors wrapped in
-// BackofficeGetRuleHierarchyConfigRequestMultiError, or nil if none found.
-func (m *BackofficeGetRuleHierarchyConfigRequest) ValidateAll() error {
-	return m.validate(true)
-}
-
-func (m *BackofficeGetRuleHierarchyConfigRequest) validate(all bool) error {
-	if m == nil {
-		return nil
-	}
-
-	var errors []error
-
-	if all {
-		switch v := interface{}(m.GetTargetOperatorContext()).(type) {
-		case interface{ ValidateAll() error }:
-			if err := v.ValidateAll(); err != nil {
-				errors = append(errors, BackofficeGetRuleHierarchyConfigRequestValidationError{
-					field:  "TargetOperatorContext",
-					reason: "embedded message failed validation",
-					cause:  err,
-				})
-			}
-		case interface{ Validate() error }:
-			if err := v.Validate(); err != nil {
-				errors = append(errors, BackofficeGetRuleHierarchyConfigRequestValidationError{
-					field:  "TargetOperatorContext",
-					reason: "embedded message failed validation",
-					cause:  err,
-				})
-			}
-		}
-	} else if v, ok := interface{}(m.GetTargetOperatorContext()).(interface{ Validate() error }); ok {
-		if err := v.Validate(); err != nil {
-			return BackofficeGetRuleHierarchyConfigRequestValidationError{
-				field:  "TargetOperatorContext",
-				reason: "embedded message failed validation",
-				cause:  err,
-			}
-		}
-	}
-
-	// no validation rules for RuleType
-
-	if len(errors) > 0 {
-		return BackofficeGetRuleHierarchyConfigRequestMultiError(errors)
-	}
-
-	return nil
-}
-
-// BackofficeGetRuleHierarchyConfigRequestMultiError is an error wrapping
-// multiple validation errors returned by
-// BackofficeGetRuleHierarchyConfigRequest.ValidateAll() if the designated
-// constraints aren't met.
-type BackofficeGetRuleHierarchyConfigRequestMultiError []error
-
-// Error returns a concatenation of all the error messages it wraps.
-func (m BackofficeGetRuleHierarchyConfigRequestMultiError) Error() string {
-	msgs := make([]string, 0, len(m))
-	for _, err := range m {
-		msgs = append(msgs, err.Error())
-	}
-	return strings.Join(msgs, "; ")
-}
-
-// AllErrors returns a list of validation violation errors.
-func (m BackofficeGetRuleHierarchyConfigRequestMultiError) AllErrors() []error { return m }
-
-// BackofficeGetRuleHierarchyConfigRequestValidationError is the validation
-// error returned by BackofficeGetRuleHierarchyConfigRequest.Validate if the
-// designated constraints aren't met.
-type BackofficeGetRuleHierarchyConfigRequestValidationError struct {
-	field  string
-	reason string
-	cause  error
-	key    bool
-}
-
-// Field function returns field value.
-func (e BackofficeGetRuleHierarchyConfigRequestValidationError) Field() string { return e.field }
-
-// Reason function returns reason value.
-func (e BackofficeGetRuleHierarchyConfigRequestValidationError) Reason() string { return e.reason }
-
-// Cause function returns cause value.
-func (e BackofficeGetRuleHierarchyConfigRequestValidationError) Cause() error { return e.cause }
-
-// Key function returns key value.
-func (e BackofficeGetRuleHierarchyConfigRequestValidationError) Key() bool { return e.key }
-
-// ErrorName returns error name.
-func (e BackofficeGetRuleHierarchyConfigRequestValidationError) ErrorName() string {
-	return "BackofficeGetRuleHierarchyConfigRequestValidationError"
-}
-
-// Error satisfies the builtin error interface
-func (e BackofficeGetRuleHierarchyConfigRequestValidationError) Error() string {
-	cause := ""
-	if e.cause != nil {
-		cause = fmt.Sprintf(" | caused by: %v", e.cause)
-	}
-
-	key := ""
-	if e.key {
-		key = "key for "
-	}
-
-	return fmt.Sprintf(
-		"invalid %sBackofficeGetRuleHierarchyConfigRequest.%s: %s%s",
-		key,
-		e.field,
-		e.reason,
-		cause)
-}
-
-var _ error = BackofficeGetRuleHierarchyConfigRequestValidationError{}
-
-var _ interface {
-	Field() string
-	Reason() string
-	Key() bool
-	Cause() error
-	ErrorName() string
-} = BackofficeGetRuleHierarchyConfigRequestValidationError{}
-
-// Validate checks the field values on
-// BackofficeUpdateRuleHierarchyConfigRequest with the rules defined in the
-// proto definition for this message. If any rules are violated, the first
-// error encountered is returned, or nil if there are no violations.
-func (m *BackofficeUpdateRuleHierarchyConfigRequest) Validate() error {
-	return m.validate(false)
-}
-
-// ValidateAll checks the field values on
-// BackofficeUpdateRuleHierarchyConfigRequest with the rules defined in the
-// proto definition for this message. If any rules are violated, the result is
-// a list of violation errors wrapped in
-// BackofficeUpdateRuleHierarchyConfigRequestMultiError, or nil if none found.
-func (m *BackofficeUpdateRuleHierarchyConfigRequest) ValidateAll() error {
-	return m.validate(true)
-}
-
-func (m *BackofficeUpdateRuleHierarchyConfigRequest) validate(all bool) error {
-	if m == nil {
-		return nil
-	}
-
-	var errors []error
-
-	if all {
-		switch v := interface{}(m.GetTargetOperatorContext()).(type) {
-		case interface{ ValidateAll() error }:
-			if err := v.ValidateAll(); err != nil {
-				errors = append(errors, BackofficeUpdateRuleHierarchyConfigRequestValidationError{
-					field:  "TargetOperatorContext",
-					reason: "embedded message failed validation",
-					cause:  err,
-				})
-			}
-		case interface{ Validate() error }:
-			if err := v.Validate(); err != nil {
-				errors = append(errors, BackofficeUpdateRuleHierarchyConfigRequestValidationError{
-					field:  "TargetOperatorContext",
-					reason: "embedded message failed validation",
-					cause:  err,
-				})
-			}
-		}
-	} else if v, ok := interface{}(m.GetTargetOperatorContext()).(interface{ Validate() error }); ok {
-		if err := v.Validate(); err != nil {
-			return BackofficeUpdateRuleHierarchyConfigRequestValidationError{
-				field:  "TargetOperatorContext",
-				reason: "embedded message failed validation",
-				cause:  err,
-			}
-		}
-	}
-
-	// no validation rules for RuleType
-
-	// no validation rules for FollowParent
-
-	if len(errors) > 0 {
-		return BackofficeUpdateRuleHierarchyConfigRequestMultiError(errors)
-	}
-
-	return nil
-}
-
-// BackofficeUpdateRuleHierarchyConfigRequestMultiError is an error wrapping
-// multiple validation errors returned by
-// BackofficeUpdateRuleHierarchyConfigRequest.ValidateAll() if the designated
-// constraints aren't met.
-type BackofficeUpdateRuleHierarchyConfigRequestMultiError []error
-
-// Error returns a concatenation of all the error messages it wraps.
-func (m BackofficeUpdateRuleHierarchyConfigRequestMultiError) Error() string {
-	msgs := make([]string, 0, len(m))
-	for _, err := range m {
-		msgs = append(msgs, err.Error())
-	}
-	return strings.Join(msgs, "; ")
-}
-
-// AllErrors returns a list of validation violation errors.
-func (m BackofficeUpdateRuleHierarchyConfigRequestMultiError) AllErrors() []error { return m }
-
-// BackofficeUpdateRuleHierarchyConfigRequestValidationError is the validation
-// error returned by BackofficeUpdateRuleHierarchyConfigRequest.Validate if
-// the designated constraints aren't met.
-type BackofficeUpdateRuleHierarchyConfigRequestValidationError struct {
-	field  string
-	reason string
-	cause  error
-	key    bool
-}
-
-// Field function returns field value.
-func (e BackofficeUpdateRuleHierarchyConfigRequestValidationError) Field() string { return e.field }
-
-// Reason function returns reason value.
-func (e BackofficeUpdateRuleHierarchyConfigRequestValidationError) Reason() string { return e.reason }
-
-// Cause function returns cause value.
-func (e BackofficeUpdateRuleHierarchyConfigRequestValidationError) Cause() error { return e.cause }
-
-// Key function returns key value.
-func (e BackofficeUpdateRuleHierarchyConfigRequestValidationError) Key() bool { return e.key }
-
-// ErrorName returns error name.
-func (e BackofficeUpdateRuleHierarchyConfigRequestValidationError) ErrorName() string {
-	return "BackofficeUpdateRuleHierarchyConfigRequestValidationError"
-}
-
-// Error satisfies the builtin error interface
-func (e BackofficeUpdateRuleHierarchyConfigRequestValidationError) Error() string {
-	cause := ""
-	if e.cause != nil {
-		cause = fmt.Sprintf(" | caused by: %v", e.cause)
-	}
-
-	key := ""
-	if e.key {
-		key = "key for "
-	}
-
-	return fmt.Sprintf(
-		"invalid %sBackofficeUpdateRuleHierarchyConfigRequest.%s: %s%s",
-		key,
-		e.field,
-		e.reason,
-		cause)
-}
-
-var _ error = BackofficeUpdateRuleHierarchyConfigRequestValidationError{}
-
-var _ interface {
-	Field() string
-	Reason() string
-	Key() bool
-	Cause() error
-	ErrorName() string
-} = BackofficeUpdateRuleHierarchyConfigRequestValidationError{}

--- a/backoffice/service/v1/backoffice_gamification.proto
+++ b/backoffice/service/v1/backoffice_gamification.proto
@@ -11,8 +11,10 @@ option java_multiple_files = true;
 option java_package = "api.backoffice.service.v1";
 
 // Gamification rules management for backoffice.
-// Proxies the gamification-service admin APIs with operator context injection
-// and HTTP bindings for the admin console.
+// Proxies the gamification-service admin APIs with operator context validation,
+// HTTP bindings, and the inheritance shape used by other backoffice-side
+// hierarchical configs (see BackofficeWallet.GetDepositRewardConfig,
+// GetAppDownloadRewardConfig).
 //
 // Only admin CRUD operations are exposed here. Runtime APIs
 // (CheckClaimEligibility, CheckGameRestriction, RecordClaim) are called
@@ -40,7 +42,10 @@ service BackofficeGamification {
     };
   }
 
-  rpc ListClaimRules(BackofficeListClaimRulesRequest) returns (api.gamification.service.v1.ListClaimRulesResponse) {
+  // Lists claim rules visible at the target operator level after hierarchy
+  // resolution. The response includes the follow_parent toggle state so the
+  // admin UI can show the rules AND the inheritance switch on the same page.
+  rpc ListClaimRules(BackofficeListClaimRulesRequest) returns (BackofficeListClaimRulesResponse) {
     option (google.api.http) = {
       post: "/v1/backoffice/gamification/claim-rule/list"
       body: "*"
@@ -68,6 +73,16 @@ service BackofficeGamification {
     };
   }
 
+  // Sets the follow_parent toggle for claim rules at the target operator level.
+  // When follow_parent=true the operator inherits its parent's effective claim
+  // rule set; when false, only the operator's own rules apply.
+  rpc SetClaimRuleFollowParent(BackofficeSetClaimRuleFollowParentRequest) returns (BackofficeSetClaimRuleFollowParentResponse) {
+    option (google.api.http) = {
+      post: "/v1/backoffice/gamification/claim-rule/follow-parent/set"
+      body: "*"
+    };
+  }
+
   // === Game Restriction Rules ===
   rpc CreateGameRestrictionRule(BackofficeCreateGameRestrictionRuleRequest) returns (api.gamification.service.v1.CreateGameRestrictionRuleResponse) {
     option (google.api.http) = {
@@ -90,7 +105,7 @@ service BackofficeGamification {
     };
   }
 
-  rpc ListGameRestrictionRules(BackofficeListGameRestrictionRulesRequest) returns (api.gamification.service.v1.ListGameRestrictionRulesResponse) {
+  rpc ListGameRestrictionRules(BackofficeListGameRestrictionRulesRequest) returns (BackofficeListGameRestrictionRulesResponse) {
     option (google.api.http) = {
       post: "/v1/backoffice/gamification/game-restriction-rule/list"
       body: "*"
@@ -118,6 +133,13 @@ service BackofficeGamification {
     };
   }
 
+  rpc SetGameRestrictionRuleFollowParent(BackofficeSetGameRestrictionRuleFollowParentRequest) returns (BackofficeSetGameRestrictionRuleFollowParentResponse) {
+    option (google.api.http) = {
+      post: "/v1/backoffice/gamification/game-restriction-rule/follow-parent/set"
+      body: "*"
+    };
+  }
+
   // === Bonus Buy Config ===
   rpc GetBonusBuyConfig(BackofficeGetBonusBuyConfigRequest) returns (api.gamification.service.v1.GetBonusBuyConfigResponse) {
     option (google.api.http) = {
@@ -129,21 +151,6 @@ service BackofficeGamification {
   rpc UpdateBonusBuyConfig(BackofficeUpdateBonusBuyConfigRequest) returns (api.gamification.service.v1.UpdateBonusBuyConfigResponse) {
     option (google.api.http) = {
       post: "/v1/backoffice/gamification/bonus-buy-config/update"
-      body: "*"
-    };
-  }
-
-  // === Rule Hierarchy Config ===
-  rpc GetRuleHierarchyConfig(BackofficeGetRuleHierarchyConfigRequest) returns (api.gamification.service.v1.GetRuleHierarchyConfigResponse) {
-    option (google.api.http) = {
-      post: "/v1/backoffice/gamification/rule-hierarchy-config/get"
-      body: "*"
-    };
-  }
-
-  rpc UpdateRuleHierarchyConfig(BackofficeUpdateRuleHierarchyConfigRequest) returns (api.gamification.service.v1.UpdateRuleHierarchyConfigResponse) {
-    option (google.api.http) = {
-      post: "/v1/backoffice/gamification/rule-hierarchy-config/update"
       body: "*"
     };
   }
@@ -172,6 +179,19 @@ message BackofficeListClaimRulesRequest {
   int32 page_size = 3;
 }
 
+// Mirrors the BackofficeWallet inheritance-shape (see GetDepositRewardConfigResponse):
+// the caller's own operator context, the follow_parent toggle, and the page of
+// rules. Each rule already carries `inherited_from_level` indicating whether
+// it was defined at this level or inherited from an ancestor.
+message BackofficeListClaimRulesResponse {
+  api.common.OperatorContext custom_operator_context = 1;
+  bool follow_parent = 2;
+  repeated api.gamification.service.v1.ClaimRule rules = 3;
+  int32 total = 4;
+  int32 page = 5;
+  int32 page_size = 6;
+}
+
 message BackofficeGetClaimRuleRequest {
   api.common.OperatorContext target_operator_context = 1;
   int64 rule_id = 2;
@@ -187,6 +207,14 @@ message BackofficeUpdateClaimRuleStatusRequest {
   api.common.OperatorContext target_operator_context = 1;
   int64 rule_id = 2;
   api.gamification.service.v1.RuleStatus status = 3;
+}
+
+message BackofficeSetClaimRuleFollowParentRequest {
+  api.common.OperatorContext target_operator_context = 1;
+  bool follow_parent = 2;
+}
+
+message BackofficeSetClaimRuleFollowParentResponse {
 }
 
 // === Game Restriction Rule Requests ===
@@ -212,6 +240,15 @@ message BackofficeListGameRestrictionRulesRequest {
   int32 page_size = 3;
 }
 
+message BackofficeListGameRestrictionRulesResponse {
+  api.common.OperatorContext custom_operator_context = 1;
+  bool follow_parent = 2;
+  repeated api.gamification.service.v1.GameRestrictionRule rules = 3;
+  int32 total = 4;
+  int32 page = 5;
+  int32 page_size = 6;
+}
+
 message BackofficeGetGameRestrictionRuleRequest {
   api.common.OperatorContext target_operator_context = 1;
   int64 rule_id = 2;
@@ -229,6 +266,14 @@ message BackofficeUpdateGameRestrictionRuleStatusRequest {
   api.gamification.service.v1.RuleStatus status = 3;
 }
 
+message BackofficeSetGameRestrictionRuleFollowParentRequest {
+  api.common.OperatorContext target_operator_context = 1;
+  bool follow_parent = 2;
+}
+
+message BackofficeSetGameRestrictionRuleFollowParentResponse {
+}
+
 // === Bonus Buy Config Requests ===
 
 message BackofficeGetBonusBuyConfigRequest {
@@ -238,19 +283,4 @@ message BackofficeGetBonusBuyConfigRequest {
 message BackofficeUpdateBonusBuyConfigRequest {
   api.common.OperatorContext target_operator_context = 1;
   bool enabled = 2;
-}
-
-// === Rule Hierarchy Config Requests ===
-
-message BackofficeGetRuleHierarchyConfigRequest {
-  api.common.OperatorContext target_operator_context = 1;
-  // "claim_rule" | "game_restriction_rule"
-  string rule_type = 2;
-}
-
-message BackofficeUpdateRuleHierarchyConfigRequest {
-  api.common.OperatorContext target_operator_context = 1;
-  // "claim_rule" | "game_restriction_rule"
-  string rule_type = 2;
-  bool follow_parent = 3;
 }

--- a/backoffice/service/v1/backoffice_gamification_grpc.pb.go
+++ b/backoffice/service/v1/backoffice_gamification_grpc.pb.go
@@ -20,24 +20,24 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	BackofficeGamification_CreateClaimRule_FullMethodName                   = "/api.backoffice.service.v1.BackofficeGamification/CreateClaimRule"
-	BackofficeGamification_UpdateClaimRule_FullMethodName                   = "/api.backoffice.service.v1.BackofficeGamification/UpdateClaimRule"
-	BackofficeGamification_DeleteClaimRule_FullMethodName                   = "/api.backoffice.service.v1.BackofficeGamification/DeleteClaimRule"
-	BackofficeGamification_ListClaimRules_FullMethodName                    = "/api.backoffice.service.v1.BackofficeGamification/ListClaimRules"
-	BackofficeGamification_GetClaimRule_FullMethodName                      = "/api.backoffice.service.v1.BackofficeGamification/GetClaimRule"
-	BackofficeGamification_UpdateClaimRulePriority_FullMethodName           = "/api.backoffice.service.v1.BackofficeGamification/UpdateClaimRulePriority"
-	BackofficeGamification_UpdateClaimRuleStatus_FullMethodName             = "/api.backoffice.service.v1.BackofficeGamification/UpdateClaimRuleStatus"
-	BackofficeGamification_CreateGameRestrictionRule_FullMethodName         = "/api.backoffice.service.v1.BackofficeGamification/CreateGameRestrictionRule"
-	BackofficeGamification_UpdateGameRestrictionRule_FullMethodName         = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRule"
-	BackofficeGamification_DeleteGameRestrictionRule_FullMethodName         = "/api.backoffice.service.v1.BackofficeGamification/DeleteGameRestrictionRule"
-	BackofficeGamification_ListGameRestrictionRules_FullMethodName          = "/api.backoffice.service.v1.BackofficeGamification/ListGameRestrictionRules"
-	BackofficeGamification_GetGameRestrictionRule_FullMethodName            = "/api.backoffice.service.v1.BackofficeGamification/GetGameRestrictionRule"
-	BackofficeGamification_UpdateGameRestrictionRulePriority_FullMethodName = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRulePriority"
-	BackofficeGamification_UpdateGameRestrictionRuleStatus_FullMethodName   = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRuleStatus"
-	BackofficeGamification_GetBonusBuyConfig_FullMethodName                 = "/api.backoffice.service.v1.BackofficeGamification/GetBonusBuyConfig"
-	BackofficeGamification_UpdateBonusBuyConfig_FullMethodName              = "/api.backoffice.service.v1.BackofficeGamification/UpdateBonusBuyConfig"
-	BackofficeGamification_GetRuleHierarchyConfig_FullMethodName            = "/api.backoffice.service.v1.BackofficeGamification/GetRuleHierarchyConfig"
-	BackofficeGamification_UpdateRuleHierarchyConfig_FullMethodName         = "/api.backoffice.service.v1.BackofficeGamification/UpdateRuleHierarchyConfig"
+	BackofficeGamification_CreateClaimRule_FullMethodName                    = "/api.backoffice.service.v1.BackofficeGamification/CreateClaimRule"
+	BackofficeGamification_UpdateClaimRule_FullMethodName                    = "/api.backoffice.service.v1.BackofficeGamification/UpdateClaimRule"
+	BackofficeGamification_DeleteClaimRule_FullMethodName                    = "/api.backoffice.service.v1.BackofficeGamification/DeleteClaimRule"
+	BackofficeGamification_ListClaimRules_FullMethodName                     = "/api.backoffice.service.v1.BackofficeGamification/ListClaimRules"
+	BackofficeGamification_GetClaimRule_FullMethodName                       = "/api.backoffice.service.v1.BackofficeGamification/GetClaimRule"
+	BackofficeGamification_UpdateClaimRulePriority_FullMethodName            = "/api.backoffice.service.v1.BackofficeGamification/UpdateClaimRulePriority"
+	BackofficeGamification_UpdateClaimRuleStatus_FullMethodName              = "/api.backoffice.service.v1.BackofficeGamification/UpdateClaimRuleStatus"
+	BackofficeGamification_SetClaimRuleFollowParent_FullMethodName           = "/api.backoffice.service.v1.BackofficeGamification/SetClaimRuleFollowParent"
+	BackofficeGamification_CreateGameRestrictionRule_FullMethodName          = "/api.backoffice.service.v1.BackofficeGamification/CreateGameRestrictionRule"
+	BackofficeGamification_UpdateGameRestrictionRule_FullMethodName          = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRule"
+	BackofficeGamification_DeleteGameRestrictionRule_FullMethodName          = "/api.backoffice.service.v1.BackofficeGamification/DeleteGameRestrictionRule"
+	BackofficeGamification_ListGameRestrictionRules_FullMethodName           = "/api.backoffice.service.v1.BackofficeGamification/ListGameRestrictionRules"
+	BackofficeGamification_GetGameRestrictionRule_FullMethodName             = "/api.backoffice.service.v1.BackofficeGamification/GetGameRestrictionRule"
+	BackofficeGamification_UpdateGameRestrictionRulePriority_FullMethodName  = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRulePriority"
+	BackofficeGamification_UpdateGameRestrictionRuleStatus_FullMethodName    = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRuleStatus"
+	BackofficeGamification_SetGameRestrictionRuleFollowParent_FullMethodName = "/api.backoffice.service.v1.BackofficeGamification/SetGameRestrictionRuleFollowParent"
+	BackofficeGamification_GetBonusBuyConfig_FullMethodName                  = "/api.backoffice.service.v1.BackofficeGamification/GetBonusBuyConfig"
+	BackofficeGamification_UpdateBonusBuyConfig_FullMethodName               = "/api.backoffice.service.v1.BackofficeGamification/UpdateBonusBuyConfig"
 )
 
 // BackofficeGamificationClient is the client API for BackofficeGamification service.
@@ -45,8 +45,10 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
 // Gamification rules management for backoffice.
-// Proxies the gamification-service admin APIs with operator context injection
-// and HTTP bindings for the admin console.
+// Proxies the gamification-service admin APIs with operator context validation,
+// HTTP bindings, and the inheritance shape used by other backoffice-side
+// hierarchical configs (see BackofficeWallet.GetDepositRewardConfig,
+// GetAppDownloadRewardConfig).
 //
 // Only admin CRUD operations are exposed here. Runtime APIs
 // (CheckClaimEligibility, CheckGameRestriction, RecordClaim) are called
@@ -56,24 +58,29 @@ type BackofficeGamificationClient interface {
 	CreateClaimRule(ctx context.Context, in *BackofficeCreateClaimRuleRequest, opts ...grpc.CallOption) (*v1.CreateClaimRuleResponse, error)
 	UpdateClaimRule(ctx context.Context, in *BackofficeUpdateClaimRuleRequest, opts ...grpc.CallOption) (*v1.UpdateClaimRuleResponse, error)
 	DeleteClaimRule(ctx context.Context, in *BackofficeDeleteClaimRuleRequest, opts ...grpc.CallOption) (*v1.DeleteClaimRuleResponse, error)
-	ListClaimRules(ctx context.Context, in *BackofficeListClaimRulesRequest, opts ...grpc.CallOption) (*v1.ListClaimRulesResponse, error)
+	// Lists claim rules visible at the target operator level after hierarchy
+	// resolution. The response includes the follow_parent toggle state so the
+	// admin UI can show the rules AND the inheritance switch on the same page.
+	ListClaimRules(ctx context.Context, in *BackofficeListClaimRulesRequest, opts ...grpc.CallOption) (*BackofficeListClaimRulesResponse, error)
 	GetClaimRule(ctx context.Context, in *BackofficeGetClaimRuleRequest, opts ...grpc.CallOption) (*v1.GetClaimRuleResponse, error)
 	UpdateClaimRulePriority(ctx context.Context, in *BackofficeUpdateClaimRulePriorityRequest, opts ...grpc.CallOption) (*v1.UpdateClaimRulePriorityResponse, error)
 	UpdateClaimRuleStatus(ctx context.Context, in *BackofficeUpdateClaimRuleStatusRequest, opts ...grpc.CallOption) (*v1.UpdateClaimRuleStatusResponse, error)
+	// Sets the follow_parent toggle for claim rules at the target operator level.
+	// When follow_parent=true the operator inherits its parent's effective claim
+	// rule set; when false, only the operator's own rules apply.
+	SetClaimRuleFollowParent(ctx context.Context, in *BackofficeSetClaimRuleFollowParentRequest, opts ...grpc.CallOption) (*BackofficeSetClaimRuleFollowParentResponse, error)
 	// === Game Restriction Rules ===
 	CreateGameRestrictionRule(ctx context.Context, in *BackofficeCreateGameRestrictionRuleRequest, opts ...grpc.CallOption) (*v1.CreateGameRestrictionRuleResponse, error)
 	UpdateGameRestrictionRule(ctx context.Context, in *BackofficeUpdateGameRestrictionRuleRequest, opts ...grpc.CallOption) (*v1.UpdateGameRestrictionRuleResponse, error)
 	DeleteGameRestrictionRule(ctx context.Context, in *BackofficeDeleteGameRestrictionRuleRequest, opts ...grpc.CallOption) (*v1.DeleteGameRestrictionRuleResponse, error)
-	ListGameRestrictionRules(ctx context.Context, in *BackofficeListGameRestrictionRulesRequest, opts ...grpc.CallOption) (*v1.ListGameRestrictionRulesResponse, error)
+	ListGameRestrictionRules(ctx context.Context, in *BackofficeListGameRestrictionRulesRequest, opts ...grpc.CallOption) (*BackofficeListGameRestrictionRulesResponse, error)
 	GetGameRestrictionRule(ctx context.Context, in *BackofficeGetGameRestrictionRuleRequest, opts ...grpc.CallOption) (*v1.GetGameRestrictionRuleResponse, error)
 	UpdateGameRestrictionRulePriority(ctx context.Context, in *BackofficeUpdateGameRestrictionRulePriorityRequest, opts ...grpc.CallOption) (*v1.UpdateGameRestrictionRulePriorityResponse, error)
 	UpdateGameRestrictionRuleStatus(ctx context.Context, in *BackofficeUpdateGameRestrictionRuleStatusRequest, opts ...grpc.CallOption) (*v1.UpdateGameRestrictionRuleStatusResponse, error)
+	SetGameRestrictionRuleFollowParent(ctx context.Context, in *BackofficeSetGameRestrictionRuleFollowParentRequest, opts ...grpc.CallOption) (*BackofficeSetGameRestrictionRuleFollowParentResponse, error)
 	// === Bonus Buy Config ===
 	GetBonusBuyConfig(ctx context.Context, in *BackofficeGetBonusBuyConfigRequest, opts ...grpc.CallOption) (*v1.GetBonusBuyConfigResponse, error)
 	UpdateBonusBuyConfig(ctx context.Context, in *BackofficeUpdateBonusBuyConfigRequest, opts ...grpc.CallOption) (*v1.UpdateBonusBuyConfigResponse, error)
-	// === Rule Hierarchy Config ===
-	GetRuleHierarchyConfig(ctx context.Context, in *BackofficeGetRuleHierarchyConfigRequest, opts ...grpc.CallOption) (*v1.GetRuleHierarchyConfigResponse, error)
-	UpdateRuleHierarchyConfig(ctx context.Context, in *BackofficeUpdateRuleHierarchyConfigRequest, opts ...grpc.CallOption) (*v1.UpdateRuleHierarchyConfigResponse, error)
 }
 
 type backofficeGamificationClient struct {
@@ -114,9 +121,9 @@ func (c *backofficeGamificationClient) DeleteClaimRule(ctx context.Context, in *
 	return out, nil
 }
 
-func (c *backofficeGamificationClient) ListClaimRules(ctx context.Context, in *BackofficeListClaimRulesRequest, opts ...grpc.CallOption) (*v1.ListClaimRulesResponse, error) {
+func (c *backofficeGamificationClient) ListClaimRules(ctx context.Context, in *BackofficeListClaimRulesRequest, opts ...grpc.CallOption) (*BackofficeListClaimRulesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(v1.ListClaimRulesResponse)
+	out := new(BackofficeListClaimRulesResponse)
 	err := c.cc.Invoke(ctx, BackofficeGamification_ListClaimRules_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -154,6 +161,16 @@ func (c *backofficeGamificationClient) UpdateClaimRuleStatus(ctx context.Context
 	return out, nil
 }
 
+func (c *backofficeGamificationClient) SetClaimRuleFollowParent(ctx context.Context, in *BackofficeSetClaimRuleFollowParentRequest, opts ...grpc.CallOption) (*BackofficeSetClaimRuleFollowParentResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BackofficeSetClaimRuleFollowParentResponse)
+	err := c.cc.Invoke(ctx, BackofficeGamification_SetClaimRuleFollowParent_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *backofficeGamificationClient) CreateGameRestrictionRule(ctx context.Context, in *BackofficeCreateGameRestrictionRuleRequest, opts ...grpc.CallOption) (*v1.CreateGameRestrictionRuleResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(v1.CreateGameRestrictionRuleResponse)
@@ -184,9 +201,9 @@ func (c *backofficeGamificationClient) DeleteGameRestrictionRule(ctx context.Con
 	return out, nil
 }
 
-func (c *backofficeGamificationClient) ListGameRestrictionRules(ctx context.Context, in *BackofficeListGameRestrictionRulesRequest, opts ...grpc.CallOption) (*v1.ListGameRestrictionRulesResponse, error) {
+func (c *backofficeGamificationClient) ListGameRestrictionRules(ctx context.Context, in *BackofficeListGameRestrictionRulesRequest, opts ...grpc.CallOption) (*BackofficeListGameRestrictionRulesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(v1.ListGameRestrictionRulesResponse)
+	out := new(BackofficeListGameRestrictionRulesResponse)
 	err := c.cc.Invoke(ctx, BackofficeGamification_ListGameRestrictionRules_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -224,6 +241,16 @@ func (c *backofficeGamificationClient) UpdateGameRestrictionRuleStatus(ctx conte
 	return out, nil
 }
 
+func (c *backofficeGamificationClient) SetGameRestrictionRuleFollowParent(ctx context.Context, in *BackofficeSetGameRestrictionRuleFollowParentRequest, opts ...grpc.CallOption) (*BackofficeSetGameRestrictionRuleFollowParentResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BackofficeSetGameRestrictionRuleFollowParentResponse)
+	err := c.cc.Invoke(ctx, BackofficeGamification_SetGameRestrictionRuleFollowParent_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *backofficeGamificationClient) GetBonusBuyConfig(ctx context.Context, in *BackofficeGetBonusBuyConfigRequest, opts ...grpc.CallOption) (*v1.GetBonusBuyConfigResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(v1.GetBonusBuyConfigResponse)
@@ -244,33 +271,15 @@ func (c *backofficeGamificationClient) UpdateBonusBuyConfig(ctx context.Context,
 	return out, nil
 }
 
-func (c *backofficeGamificationClient) GetRuleHierarchyConfig(ctx context.Context, in *BackofficeGetRuleHierarchyConfigRequest, opts ...grpc.CallOption) (*v1.GetRuleHierarchyConfigResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(v1.GetRuleHierarchyConfigResponse)
-	err := c.cc.Invoke(ctx, BackofficeGamification_GetRuleHierarchyConfig_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *backofficeGamificationClient) UpdateRuleHierarchyConfig(ctx context.Context, in *BackofficeUpdateRuleHierarchyConfigRequest, opts ...grpc.CallOption) (*v1.UpdateRuleHierarchyConfigResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(v1.UpdateRuleHierarchyConfigResponse)
-	err := c.cc.Invoke(ctx, BackofficeGamification_UpdateRuleHierarchyConfig_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 // BackofficeGamificationServer is the server API for BackofficeGamification service.
 // All implementations must embed UnimplementedBackofficeGamificationServer
 // for forward compatibility.
 //
 // Gamification rules management for backoffice.
-// Proxies the gamification-service admin APIs with operator context injection
-// and HTTP bindings for the admin console.
+// Proxies the gamification-service admin APIs with operator context validation,
+// HTTP bindings, and the inheritance shape used by other backoffice-side
+// hierarchical configs (see BackofficeWallet.GetDepositRewardConfig,
+// GetAppDownloadRewardConfig).
 //
 // Only admin CRUD operations are exposed here. Runtime APIs
 // (CheckClaimEligibility, CheckGameRestriction, RecordClaim) are called
@@ -280,24 +289,29 @@ type BackofficeGamificationServer interface {
 	CreateClaimRule(context.Context, *BackofficeCreateClaimRuleRequest) (*v1.CreateClaimRuleResponse, error)
 	UpdateClaimRule(context.Context, *BackofficeUpdateClaimRuleRequest) (*v1.UpdateClaimRuleResponse, error)
 	DeleteClaimRule(context.Context, *BackofficeDeleteClaimRuleRequest) (*v1.DeleteClaimRuleResponse, error)
-	ListClaimRules(context.Context, *BackofficeListClaimRulesRequest) (*v1.ListClaimRulesResponse, error)
+	// Lists claim rules visible at the target operator level after hierarchy
+	// resolution. The response includes the follow_parent toggle state so the
+	// admin UI can show the rules AND the inheritance switch on the same page.
+	ListClaimRules(context.Context, *BackofficeListClaimRulesRequest) (*BackofficeListClaimRulesResponse, error)
 	GetClaimRule(context.Context, *BackofficeGetClaimRuleRequest) (*v1.GetClaimRuleResponse, error)
 	UpdateClaimRulePriority(context.Context, *BackofficeUpdateClaimRulePriorityRequest) (*v1.UpdateClaimRulePriorityResponse, error)
 	UpdateClaimRuleStatus(context.Context, *BackofficeUpdateClaimRuleStatusRequest) (*v1.UpdateClaimRuleStatusResponse, error)
+	// Sets the follow_parent toggle for claim rules at the target operator level.
+	// When follow_parent=true the operator inherits its parent's effective claim
+	// rule set; when false, only the operator's own rules apply.
+	SetClaimRuleFollowParent(context.Context, *BackofficeSetClaimRuleFollowParentRequest) (*BackofficeSetClaimRuleFollowParentResponse, error)
 	// === Game Restriction Rules ===
 	CreateGameRestrictionRule(context.Context, *BackofficeCreateGameRestrictionRuleRequest) (*v1.CreateGameRestrictionRuleResponse, error)
 	UpdateGameRestrictionRule(context.Context, *BackofficeUpdateGameRestrictionRuleRequest) (*v1.UpdateGameRestrictionRuleResponse, error)
 	DeleteGameRestrictionRule(context.Context, *BackofficeDeleteGameRestrictionRuleRequest) (*v1.DeleteGameRestrictionRuleResponse, error)
-	ListGameRestrictionRules(context.Context, *BackofficeListGameRestrictionRulesRequest) (*v1.ListGameRestrictionRulesResponse, error)
+	ListGameRestrictionRules(context.Context, *BackofficeListGameRestrictionRulesRequest) (*BackofficeListGameRestrictionRulesResponse, error)
 	GetGameRestrictionRule(context.Context, *BackofficeGetGameRestrictionRuleRequest) (*v1.GetGameRestrictionRuleResponse, error)
 	UpdateGameRestrictionRulePriority(context.Context, *BackofficeUpdateGameRestrictionRulePriorityRequest) (*v1.UpdateGameRestrictionRulePriorityResponse, error)
 	UpdateGameRestrictionRuleStatus(context.Context, *BackofficeUpdateGameRestrictionRuleStatusRequest) (*v1.UpdateGameRestrictionRuleStatusResponse, error)
+	SetGameRestrictionRuleFollowParent(context.Context, *BackofficeSetGameRestrictionRuleFollowParentRequest) (*BackofficeSetGameRestrictionRuleFollowParentResponse, error)
 	// === Bonus Buy Config ===
 	GetBonusBuyConfig(context.Context, *BackofficeGetBonusBuyConfigRequest) (*v1.GetBonusBuyConfigResponse, error)
 	UpdateBonusBuyConfig(context.Context, *BackofficeUpdateBonusBuyConfigRequest) (*v1.UpdateBonusBuyConfigResponse, error)
-	// === Rule Hierarchy Config ===
-	GetRuleHierarchyConfig(context.Context, *BackofficeGetRuleHierarchyConfigRequest) (*v1.GetRuleHierarchyConfigResponse, error)
-	UpdateRuleHierarchyConfig(context.Context, *BackofficeUpdateRuleHierarchyConfigRequest) (*v1.UpdateRuleHierarchyConfigResponse, error)
 	mustEmbedUnimplementedBackofficeGamificationServer()
 }
 
@@ -317,7 +331,7 @@ func (UnimplementedBackofficeGamificationServer) UpdateClaimRule(context.Context
 func (UnimplementedBackofficeGamificationServer) DeleteClaimRule(context.Context, *BackofficeDeleteClaimRuleRequest) (*v1.DeleteClaimRuleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteClaimRule not implemented")
 }
-func (UnimplementedBackofficeGamificationServer) ListClaimRules(context.Context, *BackofficeListClaimRulesRequest) (*v1.ListClaimRulesResponse, error) {
+func (UnimplementedBackofficeGamificationServer) ListClaimRules(context.Context, *BackofficeListClaimRulesRequest) (*BackofficeListClaimRulesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListClaimRules not implemented")
 }
 func (UnimplementedBackofficeGamificationServer) GetClaimRule(context.Context, *BackofficeGetClaimRuleRequest) (*v1.GetClaimRuleResponse, error) {
@@ -329,6 +343,9 @@ func (UnimplementedBackofficeGamificationServer) UpdateClaimRulePriority(context
 func (UnimplementedBackofficeGamificationServer) UpdateClaimRuleStatus(context.Context, *BackofficeUpdateClaimRuleStatusRequest) (*v1.UpdateClaimRuleStatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateClaimRuleStatus not implemented")
 }
+func (UnimplementedBackofficeGamificationServer) SetClaimRuleFollowParent(context.Context, *BackofficeSetClaimRuleFollowParentRequest) (*BackofficeSetClaimRuleFollowParentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetClaimRuleFollowParent not implemented")
+}
 func (UnimplementedBackofficeGamificationServer) CreateGameRestrictionRule(context.Context, *BackofficeCreateGameRestrictionRuleRequest) (*v1.CreateGameRestrictionRuleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateGameRestrictionRule not implemented")
 }
@@ -338,7 +355,7 @@ func (UnimplementedBackofficeGamificationServer) UpdateGameRestrictionRule(conte
 func (UnimplementedBackofficeGamificationServer) DeleteGameRestrictionRule(context.Context, *BackofficeDeleteGameRestrictionRuleRequest) (*v1.DeleteGameRestrictionRuleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteGameRestrictionRule not implemented")
 }
-func (UnimplementedBackofficeGamificationServer) ListGameRestrictionRules(context.Context, *BackofficeListGameRestrictionRulesRequest) (*v1.ListGameRestrictionRulesResponse, error) {
+func (UnimplementedBackofficeGamificationServer) ListGameRestrictionRules(context.Context, *BackofficeListGameRestrictionRulesRequest) (*BackofficeListGameRestrictionRulesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListGameRestrictionRules not implemented")
 }
 func (UnimplementedBackofficeGamificationServer) GetGameRestrictionRule(context.Context, *BackofficeGetGameRestrictionRuleRequest) (*v1.GetGameRestrictionRuleResponse, error) {
@@ -350,17 +367,14 @@ func (UnimplementedBackofficeGamificationServer) UpdateGameRestrictionRulePriori
 func (UnimplementedBackofficeGamificationServer) UpdateGameRestrictionRuleStatus(context.Context, *BackofficeUpdateGameRestrictionRuleStatusRequest) (*v1.UpdateGameRestrictionRuleStatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateGameRestrictionRuleStatus not implemented")
 }
+func (UnimplementedBackofficeGamificationServer) SetGameRestrictionRuleFollowParent(context.Context, *BackofficeSetGameRestrictionRuleFollowParentRequest) (*BackofficeSetGameRestrictionRuleFollowParentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetGameRestrictionRuleFollowParent not implemented")
+}
 func (UnimplementedBackofficeGamificationServer) GetBonusBuyConfig(context.Context, *BackofficeGetBonusBuyConfigRequest) (*v1.GetBonusBuyConfigResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetBonusBuyConfig not implemented")
 }
 func (UnimplementedBackofficeGamificationServer) UpdateBonusBuyConfig(context.Context, *BackofficeUpdateBonusBuyConfigRequest) (*v1.UpdateBonusBuyConfigResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateBonusBuyConfig not implemented")
-}
-func (UnimplementedBackofficeGamificationServer) GetRuleHierarchyConfig(context.Context, *BackofficeGetRuleHierarchyConfigRequest) (*v1.GetRuleHierarchyConfigResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method GetRuleHierarchyConfig not implemented")
-}
-func (UnimplementedBackofficeGamificationServer) UpdateRuleHierarchyConfig(context.Context, *BackofficeUpdateRuleHierarchyConfigRequest) (*v1.UpdateRuleHierarchyConfigResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method UpdateRuleHierarchyConfig not implemented")
 }
 func (UnimplementedBackofficeGamificationServer) mustEmbedUnimplementedBackofficeGamificationServer() {
 }
@@ -510,6 +524,24 @@ func _BackofficeGamification_UpdateClaimRuleStatus_Handler(srv interface{}, ctx 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BackofficeGamification_SetClaimRuleFollowParent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BackofficeSetClaimRuleFollowParentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BackofficeGamificationServer).SetClaimRuleFollowParent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BackofficeGamification_SetClaimRuleFollowParent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BackofficeGamificationServer).SetClaimRuleFollowParent(ctx, req.(*BackofficeSetClaimRuleFollowParentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _BackofficeGamification_CreateGameRestrictionRule_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(BackofficeCreateGameRestrictionRuleRequest)
 	if err := dec(in); err != nil {
@@ -636,6 +668,24 @@ func _BackofficeGamification_UpdateGameRestrictionRuleStatus_Handler(srv interfa
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BackofficeGamification_SetGameRestrictionRuleFollowParent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BackofficeSetGameRestrictionRuleFollowParentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BackofficeGamificationServer).SetGameRestrictionRuleFollowParent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BackofficeGamification_SetGameRestrictionRuleFollowParent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BackofficeGamificationServer).SetGameRestrictionRuleFollowParent(ctx, req.(*BackofficeSetGameRestrictionRuleFollowParentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _BackofficeGamification_GetBonusBuyConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(BackofficeGetBonusBuyConfigRequest)
 	if err := dec(in); err != nil {
@@ -668,42 +718,6 @@ func _BackofficeGamification_UpdateBonusBuyConfig_Handler(srv interface{}, ctx c
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(BackofficeGamificationServer).UpdateBonusBuyConfig(ctx, req.(*BackofficeUpdateBonusBuyConfigRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _BackofficeGamification_GetRuleHierarchyConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(BackofficeGetRuleHierarchyConfigRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(BackofficeGamificationServer).GetRuleHierarchyConfig(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: BackofficeGamification_GetRuleHierarchyConfig_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(BackofficeGamificationServer).GetRuleHierarchyConfig(ctx, req.(*BackofficeGetRuleHierarchyConfigRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _BackofficeGamification_UpdateRuleHierarchyConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(BackofficeUpdateRuleHierarchyConfigRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(BackofficeGamificationServer).UpdateRuleHierarchyConfig(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: BackofficeGamification_UpdateRuleHierarchyConfig_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(BackofficeGamificationServer).UpdateRuleHierarchyConfig(ctx, req.(*BackofficeUpdateRuleHierarchyConfigRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -744,6 +758,10 @@ var BackofficeGamification_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _BackofficeGamification_UpdateClaimRuleStatus_Handler,
 		},
 		{
+			MethodName: "SetClaimRuleFollowParent",
+			Handler:    _BackofficeGamification_SetClaimRuleFollowParent_Handler,
+		},
+		{
 			MethodName: "CreateGameRestrictionRule",
 			Handler:    _BackofficeGamification_CreateGameRestrictionRule_Handler,
 		},
@@ -772,20 +790,16 @@ var BackofficeGamification_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _BackofficeGamification_UpdateGameRestrictionRuleStatus_Handler,
 		},
 		{
+			MethodName: "SetGameRestrictionRuleFollowParent",
+			Handler:    _BackofficeGamification_SetGameRestrictionRuleFollowParent_Handler,
+		},
+		{
 			MethodName: "GetBonusBuyConfig",
 			Handler:    _BackofficeGamification_GetBonusBuyConfig_Handler,
 		},
 		{
 			MethodName: "UpdateBonusBuyConfig",
 			Handler:    _BackofficeGamification_UpdateBonusBuyConfig_Handler,
-		},
-		{
-			MethodName: "GetRuleHierarchyConfig",
-			Handler:    _BackofficeGamification_GetRuleHierarchyConfig_Handler,
-		},
-		{
-			MethodName: "UpdateRuleHierarchyConfig",
-			Handler:    _BackofficeGamification_UpdateRuleHierarchyConfig_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/backoffice/service/v1/backoffice_gamification_http.pb.go
+++ b/backoffice/service/v1/backoffice_gamification_http.pb.go
@@ -27,9 +27,10 @@ const OperationBackofficeGamificationDeleteGameRestrictionRule = "/api.backoffic
 const OperationBackofficeGamificationGetBonusBuyConfig = "/api.backoffice.service.v1.BackofficeGamification/GetBonusBuyConfig"
 const OperationBackofficeGamificationGetClaimRule = "/api.backoffice.service.v1.BackofficeGamification/GetClaimRule"
 const OperationBackofficeGamificationGetGameRestrictionRule = "/api.backoffice.service.v1.BackofficeGamification/GetGameRestrictionRule"
-const OperationBackofficeGamificationGetRuleHierarchyConfig = "/api.backoffice.service.v1.BackofficeGamification/GetRuleHierarchyConfig"
 const OperationBackofficeGamificationListClaimRules = "/api.backoffice.service.v1.BackofficeGamification/ListClaimRules"
 const OperationBackofficeGamificationListGameRestrictionRules = "/api.backoffice.service.v1.BackofficeGamification/ListGameRestrictionRules"
+const OperationBackofficeGamificationSetClaimRuleFollowParent = "/api.backoffice.service.v1.BackofficeGamification/SetClaimRuleFollowParent"
+const OperationBackofficeGamificationSetGameRestrictionRuleFollowParent = "/api.backoffice.service.v1.BackofficeGamification/SetGameRestrictionRuleFollowParent"
 const OperationBackofficeGamificationUpdateBonusBuyConfig = "/api.backoffice.service.v1.BackofficeGamification/UpdateBonusBuyConfig"
 const OperationBackofficeGamificationUpdateClaimRule = "/api.backoffice.service.v1.BackofficeGamification/UpdateClaimRule"
 const OperationBackofficeGamificationUpdateClaimRulePriority = "/api.backoffice.service.v1.BackofficeGamification/UpdateClaimRulePriority"
@@ -37,7 +38,6 @@ const OperationBackofficeGamificationUpdateClaimRuleStatus = "/api.backoffice.se
 const OperationBackofficeGamificationUpdateGameRestrictionRule = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRule"
 const OperationBackofficeGamificationUpdateGameRestrictionRulePriority = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRulePriority"
 const OperationBackofficeGamificationUpdateGameRestrictionRuleStatus = "/api.backoffice.service.v1.BackofficeGamification/UpdateGameRestrictionRuleStatus"
-const OperationBackofficeGamificationUpdateRuleHierarchyConfig = "/api.backoffice.service.v1.BackofficeGamification/UpdateRuleHierarchyConfig"
 
 type BackofficeGamificationHTTPServer interface {
 	// CreateClaimRule === Claim Rules ===
@@ -50,10 +50,16 @@ type BackofficeGamificationHTTPServer interface {
 	GetBonusBuyConfig(context.Context, *BackofficeGetBonusBuyConfigRequest) (*v1.GetBonusBuyConfigResponse, error)
 	GetClaimRule(context.Context, *BackofficeGetClaimRuleRequest) (*v1.GetClaimRuleResponse, error)
 	GetGameRestrictionRule(context.Context, *BackofficeGetGameRestrictionRuleRequest) (*v1.GetGameRestrictionRuleResponse, error)
-	// GetRuleHierarchyConfig === Rule Hierarchy Config ===
-	GetRuleHierarchyConfig(context.Context, *BackofficeGetRuleHierarchyConfigRequest) (*v1.GetRuleHierarchyConfigResponse, error)
-	ListClaimRules(context.Context, *BackofficeListClaimRulesRequest) (*v1.ListClaimRulesResponse, error)
-	ListGameRestrictionRules(context.Context, *BackofficeListGameRestrictionRulesRequest) (*v1.ListGameRestrictionRulesResponse, error)
+	// ListClaimRules Lists claim rules visible at the target operator level after hierarchy
+	// resolution. The response includes the follow_parent toggle state so the
+	// admin UI can show the rules AND the inheritance switch on the same page.
+	ListClaimRules(context.Context, *BackofficeListClaimRulesRequest) (*BackofficeListClaimRulesResponse, error)
+	ListGameRestrictionRules(context.Context, *BackofficeListGameRestrictionRulesRequest) (*BackofficeListGameRestrictionRulesResponse, error)
+	// SetClaimRuleFollowParent Sets the follow_parent toggle for claim rules at the target operator level.
+	// When follow_parent=true the operator inherits its parent's effective claim
+	// rule set; when false, only the operator's own rules apply.
+	SetClaimRuleFollowParent(context.Context, *BackofficeSetClaimRuleFollowParentRequest) (*BackofficeSetClaimRuleFollowParentResponse, error)
+	SetGameRestrictionRuleFollowParent(context.Context, *BackofficeSetGameRestrictionRuleFollowParentRequest) (*BackofficeSetGameRestrictionRuleFollowParentResponse, error)
 	UpdateBonusBuyConfig(context.Context, *BackofficeUpdateBonusBuyConfigRequest) (*v1.UpdateBonusBuyConfigResponse, error)
 	UpdateClaimRule(context.Context, *BackofficeUpdateClaimRuleRequest) (*v1.UpdateClaimRuleResponse, error)
 	UpdateClaimRulePriority(context.Context, *BackofficeUpdateClaimRulePriorityRequest) (*v1.UpdateClaimRulePriorityResponse, error)
@@ -61,7 +67,6 @@ type BackofficeGamificationHTTPServer interface {
 	UpdateGameRestrictionRule(context.Context, *BackofficeUpdateGameRestrictionRuleRequest) (*v1.UpdateGameRestrictionRuleResponse, error)
 	UpdateGameRestrictionRulePriority(context.Context, *BackofficeUpdateGameRestrictionRulePriorityRequest) (*v1.UpdateGameRestrictionRulePriorityResponse, error)
 	UpdateGameRestrictionRuleStatus(context.Context, *BackofficeUpdateGameRestrictionRuleStatusRequest) (*v1.UpdateGameRestrictionRuleStatusResponse, error)
-	UpdateRuleHierarchyConfig(context.Context, *BackofficeUpdateRuleHierarchyConfigRequest) (*v1.UpdateRuleHierarchyConfigResponse, error)
 }
 
 func RegisterBackofficeGamificationHTTPServer(s *http.Server, srv BackofficeGamificationHTTPServer) {
@@ -73,6 +78,7 @@ func RegisterBackofficeGamificationHTTPServer(s *http.Server, srv BackofficeGami
 	r.POST("/v1/backoffice/gamification/claim-rule/get", _BackofficeGamification_GetClaimRule0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/claim-rule/priority/update", _BackofficeGamification_UpdateClaimRulePriority0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/claim-rule/status/update", _BackofficeGamification_UpdateClaimRuleStatus0_HTTP_Handler(srv))
+	r.POST("/v1/backoffice/gamification/claim-rule/follow-parent/set", _BackofficeGamification_SetClaimRuleFollowParent0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/game-restriction-rule/create", _BackofficeGamification_CreateGameRestrictionRule0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/game-restriction-rule/update", _BackofficeGamification_UpdateGameRestrictionRule0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/game-restriction-rule/delete", _BackofficeGamification_DeleteGameRestrictionRule0_HTTP_Handler(srv))
@@ -80,10 +86,9 @@ func RegisterBackofficeGamificationHTTPServer(s *http.Server, srv BackofficeGami
 	r.POST("/v1/backoffice/gamification/game-restriction-rule/get", _BackofficeGamification_GetGameRestrictionRule0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/game-restriction-rule/priority/update", _BackofficeGamification_UpdateGameRestrictionRulePriority0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/game-restriction-rule/status/update", _BackofficeGamification_UpdateGameRestrictionRuleStatus0_HTTP_Handler(srv))
+	r.POST("/v1/backoffice/gamification/game-restriction-rule/follow-parent/set", _BackofficeGamification_SetGameRestrictionRuleFollowParent0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/bonus-buy-config/get", _BackofficeGamification_GetBonusBuyConfig0_HTTP_Handler(srv))
 	r.POST("/v1/backoffice/gamification/bonus-buy-config/update", _BackofficeGamification_UpdateBonusBuyConfig0_HTTP_Handler(srv))
-	r.POST("/v1/backoffice/gamification/rule-hierarchy-config/get", _BackofficeGamification_GetRuleHierarchyConfig0_HTTP_Handler(srv))
-	r.POST("/v1/backoffice/gamification/rule-hierarchy-config/update", _BackofficeGamification_UpdateRuleHierarchyConfig0_HTTP_Handler(srv))
 }
 
 func _BackofficeGamification_CreateClaimRule0_HTTP_Handler(srv BackofficeGamificationHTTPServer) func(ctx http.Context) error {
@@ -169,7 +174,7 @@ func _BackofficeGamification_ListClaimRules0_HTTP_Handler(srv BackofficeGamifica
 		if err != nil {
 			return err
 		}
-		reply := out.(*v1.ListClaimRulesResponse)
+		reply := out.(*BackofficeListClaimRulesResponse)
 		return ctx.Result(200, reply)
 	}
 }
@@ -236,6 +241,28 @@ func _BackofficeGamification_UpdateClaimRuleStatus0_HTTP_Handler(srv BackofficeG
 			return err
 		}
 		reply := out.(*v1.UpdateClaimRuleStatusResponse)
+		return ctx.Result(200, reply)
+	}
+}
+
+func _BackofficeGamification_SetClaimRuleFollowParent0_HTTP_Handler(srv BackofficeGamificationHTTPServer) func(ctx http.Context) error {
+	return func(ctx http.Context) error {
+		var in BackofficeSetClaimRuleFollowParentRequest
+		if err := ctx.Bind(&in); err != nil {
+			return err
+		}
+		if err := ctx.BindQuery(&in); err != nil {
+			return err
+		}
+		http.SetOperation(ctx, OperationBackofficeGamificationSetClaimRuleFollowParent)
+		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
+			return srv.SetClaimRuleFollowParent(ctx, req.(*BackofficeSetClaimRuleFollowParentRequest))
+		})
+		out, err := h(ctx, &in)
+		if err != nil {
+			return err
+		}
+		reply := out.(*BackofficeSetClaimRuleFollowParentResponse)
 		return ctx.Result(200, reply)
 	}
 }
@@ -323,7 +350,7 @@ func _BackofficeGamification_ListGameRestrictionRules0_HTTP_Handler(srv Backoffi
 		if err != nil {
 			return err
 		}
-		reply := out.(*v1.ListGameRestrictionRulesResponse)
+		reply := out.(*BackofficeListGameRestrictionRulesResponse)
 		return ctx.Result(200, reply)
 	}
 }
@@ -394,6 +421,28 @@ func _BackofficeGamification_UpdateGameRestrictionRuleStatus0_HTTP_Handler(srv B
 	}
 }
 
+func _BackofficeGamification_SetGameRestrictionRuleFollowParent0_HTTP_Handler(srv BackofficeGamificationHTTPServer) func(ctx http.Context) error {
+	return func(ctx http.Context) error {
+		var in BackofficeSetGameRestrictionRuleFollowParentRequest
+		if err := ctx.Bind(&in); err != nil {
+			return err
+		}
+		if err := ctx.BindQuery(&in); err != nil {
+			return err
+		}
+		http.SetOperation(ctx, OperationBackofficeGamificationSetGameRestrictionRuleFollowParent)
+		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
+			return srv.SetGameRestrictionRuleFollowParent(ctx, req.(*BackofficeSetGameRestrictionRuleFollowParentRequest))
+		})
+		out, err := h(ctx, &in)
+		if err != nil {
+			return err
+		}
+		reply := out.(*BackofficeSetGameRestrictionRuleFollowParentResponse)
+		return ctx.Result(200, reply)
+	}
+}
+
 func _BackofficeGamification_GetBonusBuyConfig0_HTTP_Handler(srv BackofficeGamificationHTTPServer) func(ctx http.Context) error {
 	return func(ctx http.Context) error {
 		var in BackofficeGetBonusBuyConfigRequest
@@ -438,50 +487,6 @@ func _BackofficeGamification_UpdateBonusBuyConfig0_HTTP_Handler(srv BackofficeGa
 	}
 }
 
-func _BackofficeGamification_GetRuleHierarchyConfig0_HTTP_Handler(srv BackofficeGamificationHTTPServer) func(ctx http.Context) error {
-	return func(ctx http.Context) error {
-		var in BackofficeGetRuleHierarchyConfigRequest
-		if err := ctx.Bind(&in); err != nil {
-			return err
-		}
-		if err := ctx.BindQuery(&in); err != nil {
-			return err
-		}
-		http.SetOperation(ctx, OperationBackofficeGamificationGetRuleHierarchyConfig)
-		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
-			return srv.GetRuleHierarchyConfig(ctx, req.(*BackofficeGetRuleHierarchyConfigRequest))
-		})
-		out, err := h(ctx, &in)
-		if err != nil {
-			return err
-		}
-		reply := out.(*v1.GetRuleHierarchyConfigResponse)
-		return ctx.Result(200, reply)
-	}
-}
-
-func _BackofficeGamification_UpdateRuleHierarchyConfig0_HTTP_Handler(srv BackofficeGamificationHTTPServer) func(ctx http.Context) error {
-	return func(ctx http.Context) error {
-		var in BackofficeUpdateRuleHierarchyConfigRequest
-		if err := ctx.Bind(&in); err != nil {
-			return err
-		}
-		if err := ctx.BindQuery(&in); err != nil {
-			return err
-		}
-		http.SetOperation(ctx, OperationBackofficeGamificationUpdateRuleHierarchyConfig)
-		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
-			return srv.UpdateRuleHierarchyConfig(ctx, req.(*BackofficeUpdateRuleHierarchyConfigRequest))
-		})
-		out, err := h(ctx, &in)
-		if err != nil {
-			return err
-		}
-		reply := out.(*v1.UpdateRuleHierarchyConfigResponse)
-		return ctx.Result(200, reply)
-	}
-}
-
 type BackofficeGamificationHTTPClient interface {
 	// CreateClaimRule === Claim Rules ===
 	CreateClaimRule(ctx context.Context, req *BackofficeCreateClaimRuleRequest, opts ...http.CallOption) (rsp *v1.CreateClaimRuleResponse, err error)
@@ -493,10 +498,16 @@ type BackofficeGamificationHTTPClient interface {
 	GetBonusBuyConfig(ctx context.Context, req *BackofficeGetBonusBuyConfigRequest, opts ...http.CallOption) (rsp *v1.GetBonusBuyConfigResponse, err error)
 	GetClaimRule(ctx context.Context, req *BackofficeGetClaimRuleRequest, opts ...http.CallOption) (rsp *v1.GetClaimRuleResponse, err error)
 	GetGameRestrictionRule(ctx context.Context, req *BackofficeGetGameRestrictionRuleRequest, opts ...http.CallOption) (rsp *v1.GetGameRestrictionRuleResponse, err error)
-	// GetRuleHierarchyConfig === Rule Hierarchy Config ===
-	GetRuleHierarchyConfig(ctx context.Context, req *BackofficeGetRuleHierarchyConfigRequest, opts ...http.CallOption) (rsp *v1.GetRuleHierarchyConfigResponse, err error)
-	ListClaimRules(ctx context.Context, req *BackofficeListClaimRulesRequest, opts ...http.CallOption) (rsp *v1.ListClaimRulesResponse, err error)
-	ListGameRestrictionRules(ctx context.Context, req *BackofficeListGameRestrictionRulesRequest, opts ...http.CallOption) (rsp *v1.ListGameRestrictionRulesResponse, err error)
+	// ListClaimRules Lists claim rules visible at the target operator level after hierarchy
+	// resolution. The response includes the follow_parent toggle state so the
+	// admin UI can show the rules AND the inheritance switch on the same page.
+	ListClaimRules(ctx context.Context, req *BackofficeListClaimRulesRequest, opts ...http.CallOption) (rsp *BackofficeListClaimRulesResponse, err error)
+	ListGameRestrictionRules(ctx context.Context, req *BackofficeListGameRestrictionRulesRequest, opts ...http.CallOption) (rsp *BackofficeListGameRestrictionRulesResponse, err error)
+	// SetClaimRuleFollowParent Sets the follow_parent toggle for claim rules at the target operator level.
+	// When follow_parent=true the operator inherits its parent's effective claim
+	// rule set; when false, only the operator's own rules apply.
+	SetClaimRuleFollowParent(ctx context.Context, req *BackofficeSetClaimRuleFollowParentRequest, opts ...http.CallOption) (rsp *BackofficeSetClaimRuleFollowParentResponse, err error)
+	SetGameRestrictionRuleFollowParent(ctx context.Context, req *BackofficeSetGameRestrictionRuleFollowParentRequest, opts ...http.CallOption) (rsp *BackofficeSetGameRestrictionRuleFollowParentResponse, err error)
 	UpdateBonusBuyConfig(ctx context.Context, req *BackofficeUpdateBonusBuyConfigRequest, opts ...http.CallOption) (rsp *v1.UpdateBonusBuyConfigResponse, err error)
 	UpdateClaimRule(ctx context.Context, req *BackofficeUpdateClaimRuleRequest, opts ...http.CallOption) (rsp *v1.UpdateClaimRuleResponse, err error)
 	UpdateClaimRulePriority(ctx context.Context, req *BackofficeUpdateClaimRulePriorityRequest, opts ...http.CallOption) (rsp *v1.UpdateClaimRulePriorityResponse, err error)
@@ -504,7 +515,6 @@ type BackofficeGamificationHTTPClient interface {
 	UpdateGameRestrictionRule(ctx context.Context, req *BackofficeUpdateGameRestrictionRuleRequest, opts ...http.CallOption) (rsp *v1.UpdateGameRestrictionRuleResponse, err error)
 	UpdateGameRestrictionRulePriority(ctx context.Context, req *BackofficeUpdateGameRestrictionRulePriorityRequest, opts ...http.CallOption) (rsp *v1.UpdateGameRestrictionRulePriorityResponse, err error)
 	UpdateGameRestrictionRuleStatus(ctx context.Context, req *BackofficeUpdateGameRestrictionRuleStatusRequest, opts ...http.CallOption) (rsp *v1.UpdateGameRestrictionRuleStatusResponse, err error)
-	UpdateRuleHierarchyConfig(ctx context.Context, req *BackofficeUpdateRuleHierarchyConfigRequest, opts ...http.CallOption) (rsp *v1.UpdateRuleHierarchyConfigResponse, err error)
 }
 
 type BackofficeGamificationHTTPClientImpl struct {
@@ -609,22 +619,11 @@ func (c *BackofficeGamificationHTTPClientImpl) GetGameRestrictionRule(ctx contex
 	return &out, nil
 }
 
-// GetRuleHierarchyConfig === Rule Hierarchy Config ===
-func (c *BackofficeGamificationHTTPClientImpl) GetRuleHierarchyConfig(ctx context.Context, in *BackofficeGetRuleHierarchyConfigRequest, opts ...http.CallOption) (*v1.GetRuleHierarchyConfigResponse, error) {
-	var out v1.GetRuleHierarchyConfigResponse
-	pattern := "/v1/backoffice/gamification/rule-hierarchy-config/get"
-	path := binding.EncodeURL(pattern, in, false)
-	opts = append(opts, http.Operation(OperationBackofficeGamificationGetRuleHierarchyConfig))
-	opts = append(opts, http.PathTemplate(pattern))
-	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
-func (c *BackofficeGamificationHTTPClientImpl) ListClaimRules(ctx context.Context, in *BackofficeListClaimRulesRequest, opts ...http.CallOption) (*v1.ListClaimRulesResponse, error) {
-	var out v1.ListClaimRulesResponse
+// ListClaimRules Lists claim rules visible at the target operator level after hierarchy
+// resolution. The response includes the follow_parent toggle state so the
+// admin UI can show the rules AND the inheritance switch on the same page.
+func (c *BackofficeGamificationHTTPClientImpl) ListClaimRules(ctx context.Context, in *BackofficeListClaimRulesRequest, opts ...http.CallOption) (*BackofficeListClaimRulesResponse, error) {
+	var out BackofficeListClaimRulesResponse
 	pattern := "/v1/backoffice/gamification/claim-rule/list"
 	path := binding.EncodeURL(pattern, in, false)
 	opts = append(opts, http.Operation(OperationBackofficeGamificationListClaimRules))
@@ -636,11 +635,40 @@ func (c *BackofficeGamificationHTTPClientImpl) ListClaimRules(ctx context.Contex
 	return &out, nil
 }
 
-func (c *BackofficeGamificationHTTPClientImpl) ListGameRestrictionRules(ctx context.Context, in *BackofficeListGameRestrictionRulesRequest, opts ...http.CallOption) (*v1.ListGameRestrictionRulesResponse, error) {
-	var out v1.ListGameRestrictionRulesResponse
+func (c *BackofficeGamificationHTTPClientImpl) ListGameRestrictionRules(ctx context.Context, in *BackofficeListGameRestrictionRulesRequest, opts ...http.CallOption) (*BackofficeListGameRestrictionRulesResponse, error) {
+	var out BackofficeListGameRestrictionRulesResponse
 	pattern := "/v1/backoffice/gamification/game-restriction-rule/list"
 	path := binding.EncodeURL(pattern, in, false)
 	opts = append(opts, http.Operation(OperationBackofficeGamificationListGameRestrictionRules))
+	opts = append(opts, http.PathTemplate(pattern))
+	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SetClaimRuleFollowParent Sets the follow_parent toggle for claim rules at the target operator level.
+// When follow_parent=true the operator inherits its parent's effective claim
+// rule set; when false, only the operator's own rules apply.
+func (c *BackofficeGamificationHTTPClientImpl) SetClaimRuleFollowParent(ctx context.Context, in *BackofficeSetClaimRuleFollowParentRequest, opts ...http.CallOption) (*BackofficeSetClaimRuleFollowParentResponse, error) {
+	var out BackofficeSetClaimRuleFollowParentResponse
+	pattern := "/v1/backoffice/gamification/claim-rule/follow-parent/set"
+	path := binding.EncodeURL(pattern, in, false)
+	opts = append(opts, http.Operation(OperationBackofficeGamificationSetClaimRuleFollowParent))
+	opts = append(opts, http.PathTemplate(pattern))
+	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *BackofficeGamificationHTTPClientImpl) SetGameRestrictionRuleFollowParent(ctx context.Context, in *BackofficeSetGameRestrictionRuleFollowParentRequest, opts ...http.CallOption) (*BackofficeSetGameRestrictionRuleFollowParentResponse, error) {
+	var out BackofficeSetGameRestrictionRuleFollowParentResponse
+	pattern := "/v1/backoffice/gamification/game-restriction-rule/follow-parent/set"
+	path := binding.EncodeURL(pattern, in, false)
+	opts = append(opts, http.Operation(OperationBackofficeGamificationSetGameRestrictionRuleFollowParent))
 	opts = append(opts, http.PathTemplate(pattern))
 	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
 	if err != nil {
@@ -732,19 +760,6 @@ func (c *BackofficeGamificationHTTPClientImpl) UpdateGameRestrictionRuleStatus(c
 	pattern := "/v1/backoffice/gamification/game-restriction-rule/status/update"
 	path := binding.EncodeURL(pattern, in, false)
 	opts = append(opts, http.Operation(OperationBackofficeGamificationUpdateGameRestrictionRuleStatus))
-	opts = append(opts, http.PathTemplate(pattern))
-	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
-func (c *BackofficeGamificationHTTPClientImpl) UpdateRuleHierarchyConfig(ctx context.Context, in *BackofficeUpdateRuleHierarchyConfigRequest, opts ...http.CallOption) (*v1.UpdateRuleHierarchyConfigResponse, error) {
-	var out v1.UpdateRuleHierarchyConfigResponse
-	pattern := "/v1/backoffice/gamification/rule-hierarchy-config/update"
-	path := binding.EncodeURL(pattern, in, false)
-	opts = append(opts, http.Operation(OperationBackofficeGamificationUpdateRuleHierarchyConfig))
 	opts = append(opts, http.PathTemplate(pattern))
 	err := c.cc.Invoke(ctx, "POST", path, in, &out, opts...)
 	if err != nil {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4835,6 +4835,28 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/api.gamification.service.v1.DeleteClaimRuleResponse'
+    /v1/backoffice/gamification/claim-rule/follow-parent/set:
+        post:
+            tags:
+                - BackofficeGamification
+            description: |-
+                Sets the follow_parent toggle for claim rules at the target operator level.
+                 When follow_parent=true the operator inherits its parent's effective claim
+                 rule set; when false, only the operator's own rules apply.
+            operationId: BackofficeGamification_SetClaimRuleFollowParent
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentResponse'
     /v1/backoffice/gamification/claim-rule/get:
         post:
             tags:
@@ -4857,6 +4879,10 @@ paths:
         post:
             tags:
                 - BackofficeGamification
+            description: |-
+                Lists claim rules visible at the target operator level after hierarchy
+                 resolution. The response includes the follow_parent toggle state so the
+                 admin UI can show the rules AND the inheritance switch on the same page.
             operationId: BackofficeGamification_ListClaimRules
             requestBody:
                 content:
@@ -4870,7 +4896,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/api.gamification.service.v1.ListClaimRulesResponse'
+                                $ref: '#/components/schemas/api.backoffice.service.v1.BackofficeListClaimRulesResponse'
     /v1/backoffice/gamification/claim-rule/priority/update:
         post:
             tags:
@@ -4962,6 +4988,24 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/api.gamification.service.v1.DeleteGameRestrictionRuleResponse'
+    /v1/backoffice/gamification/game-restriction-rule/follow-parent/set:
+        post:
+            tags:
+                - BackofficeGamification
+            operationId: BackofficeGamification_SetGameRestrictionRuleFollowParent
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentResponse'
     /v1/backoffice/gamification/game-restriction-rule/get:
         post:
             tags:
@@ -4997,7 +5041,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/api.gamification.service.v1.ListGameRestrictionRulesResponse'
+                                $ref: '#/components/schemas/api.backoffice.service.v1.BackofficeListGameRestrictionRulesResponse'
     /v1/backoffice/gamification/game-restriction-rule/priority/update:
         post:
             tags:
@@ -5052,43 +5096,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/api.gamification.service.v1.UpdateGameRestrictionRuleResponse'
-    /v1/backoffice/gamification/rule-hierarchy-config/get:
-        post:
-            tags:
-                - BackofficeGamification
-            description: === Rule Hierarchy Config ===
-            operationId: BackofficeGamification_GetRuleHierarchyConfig
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/api.backoffice.service.v1.BackofficeGetRuleHierarchyConfigRequest'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/api.gamification.service.v1.GetRuleHierarchyConfigResponse'
-    /v1/backoffice/gamification/rule-hierarchy-config/update:
-        post:
-            tags:
-                - BackofficeGamification
-            operationId: BackofficeGamification_UpdateRuleHierarchyConfig
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/api.backoffice.service.v1.BackofficeUpdateRuleHierarchyConfigRequest'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/api.gamification.service.v1.UpdateRuleHierarchyConfigResponse'
     /v1/backoffice/notification/channel/create:
         post:
             tags:
@@ -15597,14 +15604,6 @@ components:
                     $ref: '#/components/schemas/api.common.OperatorContext'
                 ruleId:
                     type: string
-        api.backoffice.service.v1.BackofficeGetRuleHierarchyConfigRequest:
-            type: object
-            properties:
-                targetOperatorContext:
-                    $ref: '#/components/schemas/api.common.OperatorContext'
-                ruleType:
-                    type: string
-                    description: '"claim_rule" | "game_restriction_rule"'
         api.backoffice.service.v1.BackofficeListClaimRulesRequest:
             type: object
             properties:
@@ -15616,11 +15615,56 @@ components:
                 pageSize:
                     type: integer
                     format: int32
+        api.backoffice.service.v1.BackofficeListClaimRulesResponse:
+            type: object
+            properties:
+                customOperatorContext:
+                    $ref: '#/components/schemas/api.common.OperatorContext'
+                followParent:
+                    type: boolean
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/api.gamification.service.v1.ClaimRule'
+                total:
+                    type: integer
+                    format: int32
+                page:
+                    type: integer
+                    format: int32
+                pageSize:
+                    type: integer
+                    format: int32
+            description: |-
+                Mirrors the BackofficeWallet inheritance-shape (see GetDepositRewardConfigResponse):
+                 the caller's own operator context, the follow_parent toggle, and the page of
+                 rules. Each rule already carries `inherited_from_level` indicating whether
+                 it was defined at this level or inherited from an ancestor.
         api.backoffice.service.v1.BackofficeListGameRestrictionRulesRequest:
             type: object
             properties:
                 targetOperatorContext:
                     $ref: '#/components/schemas/api.common.OperatorContext'
+                page:
+                    type: integer
+                    format: int32
+                pageSize:
+                    type: integer
+                    format: int32
+        api.backoffice.service.v1.BackofficeListGameRestrictionRulesResponse:
+            type: object
+            properties:
+                customOperatorContext:
+                    $ref: '#/components/schemas/api.common.OperatorContext'
+                followParent:
+                    type: boolean
+                rules:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/api.gamification.service.v1.GameRestrictionRule'
+                total:
+                    type: integer
+                    format: int32
                 page:
                     type: integer
                     format: int32
@@ -15781,6 +15825,26 @@ components:
                 gamesRemoved:
                     type: integer
                     format: int32
+        api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentRequest:
+            type: object
+            properties:
+                targetOperatorContext:
+                    $ref: '#/components/schemas/api.common.OperatorContext'
+                followParent:
+                    type: boolean
+        api.backoffice.service.v1.BackofficeSetClaimRuleFollowParentResponse:
+            type: object
+            properties: {}
+        api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentRequest:
+            type: object
+            properties:
+                targetOperatorContext:
+                    $ref: '#/components/schemas/api.common.OperatorContext'
+                followParent:
+                    type: boolean
+        api.backoffice.service.v1.BackofficeSetGameRestrictionRuleFollowParentResponse:
+            type: object
+            properties: {}
         api.backoffice.service.v1.BackofficeUpdateBonusBuyConfigRequest:
             type: object
             properties:
@@ -15878,16 +15942,6 @@ components:
         api.backoffice.service.v1.BackofficeUpdateGameTagResponse:
             type: object
             properties: {}
-        api.backoffice.service.v1.BackofficeUpdateRuleHierarchyConfigRequest:
-            type: object
-            properties:
-                targetOperatorContext:
-                    $ref: '#/components/schemas/api.common.OperatorContext'
-                ruleType:
-                    type: string
-                    description: '"claim_rule" | "game_restriction_rule"'
-                followParent:
-                    type: boolean
         api.backoffice.service.v1.BalancesSummaryRow:
             type: object
             properties:
@@ -29780,46 +29834,6 @@ components:
             properties:
                 rule:
                     $ref: '#/components/schemas/api.gamification.service.v1.GameRestrictionRule'
-        api.gamification.service.v1.GetRuleHierarchyConfigResponse:
-            type: object
-            properties:
-                followParent:
-                    type: boolean
-                level:
-                    type: string
-                    description: '"system" | "retailer" | "company" | "operator"'
-        api.gamification.service.v1.ListClaimRulesResponse:
-            type: object
-            properties:
-                rules:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/api.gamification.service.v1.ClaimRule'
-                total:
-                    type: integer
-                    format: int32
-                page:
-                    type: integer
-                    format: int32
-                pageSize:
-                    type: integer
-                    format: int32
-        api.gamification.service.v1.ListGameRestrictionRulesResponse:
-            type: object
-            properties:
-                rules:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/api.gamification.service.v1.GameRestrictionRule'
-                total:
-                    type: integer
-                    format: int32
-                page:
-                    type: integer
-                    format: int32
-                pageSize:
-                    type: integer
-                    format: int32
         api.gamification.service.v1.UpdateBonusBuyConfigResponse:
             type: object
             properties:
@@ -29845,9 +29859,6 @@ components:
                 rule:
                     $ref: '#/components/schemas/api.gamification.service.v1.GameRestrictionRule'
         api.gamification.service.v1.UpdateGameRestrictionRuleStatusResponse:
-            type: object
-            properties: {}
-        api.gamification.service.v1.UpdateRuleHierarchyConfigResponse:
             type: object
             properties: {}
         api.push.service.v1.BatchCreateSMSChannelRatesResponse:
@@ -37706,8 +37717,10 @@ tags:
     - name: BackofficeGamification
       description: |-
         Gamification rules management for backoffice.
-         Proxies the gamification-service admin APIs with operator context injection
-         and HTTP bindings for the admin console.
+         Proxies the gamification-service admin APIs with operator context validation,
+         HTTP bindings, and the inheritance shape used by other backoffice-side
+         hierarchical configs (see BackofficeWallet.GetDepositRewardConfig,
+         GetAppDownloadRewardConfig).
 
          Only admin CRUD operations are exposed here. Runtime APIs
          (CheckClaimEligibility, CheckGameRestriction, RecordClaim) are called


### PR DESCRIPTION
## Summary
- List responses include \`follow_parent\` inline (matches \`GetDepositRewardConfig\` / \`GetAppDownloadRewardConfig\` pattern)
- Replaces generic \`GetRuleHierarchyConfig\` / \`UpdateRuleHierarchyConfig\` (keyed by \`rule_type\` string) with typed \`SetClaimRuleFollowParent\` / \`SetGameRestrictionRuleFollowParent\` endpoints
- Rules continue to carry \`inherited_from_level\` per row so the UI can show provenance

## Why
Matches the shape already established by other hierarchical backoffice configs (see \`BackofficeWallet.GetDepositRewardConfig\`). The admin UI can now render rules and the follow-parent toggle from a single call.

## Test plan
- [x] \`make api\` regenerates cleanly
- [x] \`go build ./backoffice/service/v1/...\` passes
- [ ] Update meepo-backoffice-service to the new shape in a follow-up PR