### PR TITLE
docs(game): document Game_ListLiveEvents request/response schema

### DIFF
--- a/game/service/v1/game.pb.go
+++ b/game/service/v1/game.pb.go
@@ -8994,6 +8994,21 @@ type ListLiveEventsRequest struct {
 	//	}
 	//
 	// ```
+	//
+	// Example F — list outright (championship / futures) markets, e.g. a Soccer "winner" board:
+	//
+	// ```json
+	//
+	//	{
+	//	  "sportID": "1",
+	//	  "isLive": "false",
+	//	  "eventType": "Outright",
+	//	  "take": "20",
+	//	  "skip": "0",
+	//	  "locale": "en"
+	//	}
+	//
+	// ```
 	RequestPayload *structpb.Struct `protobuf:"bytes,2,opt,name=request_payload,json=requestPayload,proto3" json:"request_payload,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache

--- a/game/service/v1/game.pb.go
+++ b/game/service/v1/game.pb.go
@@ -8978,6 +8978,22 @@ type ListLiveEventsRequest struct {
 	//	}
 	//
 	// ```
+	//
+	// Example E — list events for a specific league by `leagueID` (e.g. a league landing page):
+	//
+	// ```json
+	//
+	//	{
+	//	  "sportID": "1",
+	//	  "isLive": "false",
+	//	  "eventType": "Fixture",
+	//	  "take": "20",
+	//	  "skip": "0",
+	//	  "locale": "en",
+	//	  "leagueID": "2627"
+	//	}
+	//
+	// ```
 	RequestPayload *structpb.Struct `protobuf:"bytes,2,opt,name=request_payload,json=requestPayload,proto3" json:"request_payload,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache

--- a/game/service/v1/game.pb.go
+++ b/game/service/v1/game.pb.go
@@ -8880,10 +8880,62 @@ func (x *GetGameInfoResponse) GetGameInfo() *GameInfo {
 	return nil
 }
 
+// ListLiveEvents - list events (in-play and pre-match) of a sports/live-betting game by proxying
+// `request_payload` to the upstream aggregator's events endpoint.
+//
+// Behavior:
+// - The upstream endpoint and provider credentials are resolved from `game_id`.
+// - `request_payload` is forwarded as-is; the operator's API key/secret are used to sign the call.
+// - Responses are cached for 30 seconds keyed by `game_id` + payload hash and shared across operators.
+//
+// ## request_payload fields (forwarded verbatim to the provider)
+//
+// | Field         | Type   | Required | Description                                                            |
+// | ---           | ---    | ---      | ---                                                                    |
+// | `sportID`     | string | yes      | Sport ID filter — see "Sport IDs" below.                               |
+// | `isLive`      | string | yes      | `"true"` for in-play (live) events, `"false"` for pre-match (early).   |
+// | `eventType`   | string | yes      | `"Fixture"` (head-to-head) or `"Outright"` (championship/futures).     |
+// | `take`        | string | yes      | Page size — number of events to return.                                |
+// | `skip`        | string | yes      | Page offset — number of events to skip.                                |
+// | `locale`      | string | yes      | 2-letter language code (e.g. `"en"`, `"zh"`).                          |
+// | `leagueID`    | string | no       | Filter by a specific league ID.                                        |
+// | `eventID`     | string | no       | Filter by a specific event ID.                                         |
+// | `isTopLeague` | string | no       | Limit to provider-flagged top leagues.                                 |
+//
+// ## Sport IDs (subset; the provider's full list may change over time)
+//
+// `1` Soccer, `2` Basketball, `3` American Football, `6` Tennis, `7` Baseball, `8` Ice Hockey,
+// `10` Handball, `11` Rugby League, `12` Golf, `13` Snooker / Pool, `14` Motor Racing, `15` Darts,
+// `19` Volleyball, `20` Boxing, `25` Futsal, `26` Table Tennis, `34` Badminton, `35` Rugby Union,
+// `43` MMA, `59` Cricket, `61` Horse Racing, `64` E-Sports, `66` Greyhounds, `82` Muay Thai,
+// `136` Kabaddi, `220` LOL, `221` DOTA2, `228` Valorant, `229` KOG, `230` CS2.
 type ListLiveEventsRequest struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	GameId         string                 `protobuf:"bytes,1,opt,name=game_id,json=gameId,proto3" json:"game_id,omitempty"`
-	RequestPayload *structpb.Struct       `protobuf:"bytes,2,opt,name=request_payload,json=requestPayload,proto3" json:"request_payload,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Game ID identifying which live/sports product to query (used to resolve the upstream endpoint and credentials).
+	GameId string `protobuf:"bytes,1,opt,name=game_id,json=gameId,proto3" json:"game_id,omitempty"`
+	// Filter payload forwarded as-is to the upstream aggregator. Field shape follows the provider's API
+	// (see the table in the message-level docs above).
+	//
+	// Example — pull up to 10 in-play basketball head-to-head events, in English:
+	//
+	// ```json
+	//
+	//	{
+	//	  "sportID": "2",
+	//	  "isLive": "true",
+	//	  "eventType": "Fixture",
+	//	  "take": "10",
+	//	  "skip": "0",
+	//	  "locale": "en",
+	//	  "leagueID": "",
+	//	  "eventID": "",
+	//	  "isTopLeague": ""
+	//	}
+	//
+	// ```
+	//
+	// An empty payload returns the aggregator's default event list.
+	RequestPayload *structpb.Struct `protobuf:"bytes,2,opt,name=request_payload,json=requestPayload,proto3" json:"request_payload,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -8932,9 +8984,77 @@ func (x *ListLiveEventsRequest) GetRequestPayload() *structpb.Struct {
 	return nil
 }
 
+// ListLiveEventsResponse - events returned by the upstream aggregator (passed through without schema enforcement).
+//
+// ## Common event fields (provider-defined)
+//
+// - `_id` — event ID.
+// - `IsLive` — whether the event is currently in-play.
+// - `IsSuspended` — whether the event is temporarily suspended.
+// - `IsTopLeague` — whether the event belongs to a provider-flagged top league (informational only).
+// - `LeagueId` / `MasterLeagueId` — league IDs (`MasterLeagueId` is stable across seasons; usable for league logo lookup).
+// - `SportId` — sport ID (see ListLiveEventsRequest).
+// - `StartEventDate` — scheduled start time.
+// - `Status` — event status enum: `0` NotStarted, `1` InProgress, `2` RaceOff, `3` Resulted, `4` Cancelled.
+// - `Type` — `"Fixture"` or `"Outright"`.
+// - `EventName` / `BetslipLine` / `SportName` / `LeagueName` / `regionCode` / `regionName` — display fields.
+// - `TotalActiveMarketsCount` — number of active markets on the event.
+// - `Participants[]` — `{_id, Name, VenueRole}` (team / player info; `VenueRole` indicates country or region).
+// - `Score` — `{HomeScore, AwayScore}` for in-play events.
+// - `Markets[]` — `{_id, Name, IsSuspended, LeagueId, StartDate, MarketType, Selections}`.
+//   - `MarketType` — `{_id, Name}` (e.g. handicap / over-under / moneyline).
+//
+// - `Selections[]` — `{_id, BetslipLine, IsDisabled, Name, IsOption, TrueOdds, OutcomeType, Points, Status, DisplayOdds}`.
+//   - `IsOption` — whether this is the main handicap line or a derived (alternate) line.
+//   - `TrueOdds` — true odds in decimal (European) format.
+//   - `OutcomeType` — UI hint, e.g. `"Over"` / `"Under"`, `"Home"` / `"Away"` / `"Tie"`.
+//   - `Points` — handicap / line value for the selection.
+//   - `DisplayOdds` — `{Decimal, HK, Indo, Malay}`. `Decimal` is also the settlement format.
+//
+// On upstream errors, an entry may instead carry `errorMessage`, `errorCode`,
+// `errorMessages[].{message, parameterName, providedValue}`, and `sessionId` for support diagnostics.
 type ListLiveEventsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Events        []*structpb.Struct     `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Event objects passed through from the aggregator. See the message-level docs for the field schema.
+	//
+	// ```json
+	// [
+	//
+	//	{
+	//	  "_id": "evt_12345",
+	//	  "SportId": 2,
+	//	  "LeagueName": "NBA",
+	//	  "EventName": "Lakers vs Celtics",
+	//	  "StartEventDate": "2026-04-26T20:00:00Z",
+	//	  "Status": 1,
+	//	  "Type": "Fixture",
+	//	  "Participants": [
+	//	    {"_id": "t_1", "Name": "Lakers", "VenueRole": "Home"},
+	//	    {"_id": "t_2", "Name": "Celtics", "VenueRole": "Away"}
+	//	  ],
+	//	  "Score": {"HomeScore": 42, "AwayScore": 38},
+	//	  "Markets": [
+	//	    {
+	//	      "_id": "mkt_1",
+	//	      "Name": "Moneyline",
+	//	      "MarketType": {"_id": "mt_ml", "Name": "Moneyline"},
+	//	      "Selections": [
+	//	        {
+	//	          "_id": "sel_1",
+	//	          "Name": "Lakers",
+	//	          "OutcomeType": "Home",
+	//	          "TrueOdds": 1.85,
+	//	          "DisplayOdds": {"Decimal": "1.85", "HK": "0.85", "Indo": "-1.18", "Malay": "0.85"},
+	//	          "Status": 1
+	//	        }
+	//	      ]
+	//	    }
+	//	  ]
+	//	}
+	//
+	// ]
+	// ```
+	Events        []*structpb.Struct `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/game/service/v1/game.pb.go
+++ b/game/service/v1/game.pb.go
@@ -8890,17 +8890,17 @@ func (x *GetGameInfoResponse) GetGameInfo() *GameInfo {
 //
 // ## request_payload fields (forwarded verbatim to the provider)
 //
-// | Field         | Type   | Required | Description                                                            |
-// | ---           | ---    | ---      | ---                                                                    |
-// | `sportID`     | string | yes      | Sport ID filter — see "Sport IDs" below.                               |
-// | `isLive`      | string | yes      | `"true"` for in-play (live) events, `"false"` for pre-match (early).   |
-// | `eventType`   | string | yes      | `"Fixture"` (head-to-head) or `"Outright"` (championship/futures).     |
-// | `take`        | string | yes      | Page size — number of events to return.                                |
-// | `skip`        | string | yes      | Page offset — number of events to skip.                                |
-// | `locale`      | string | yes      | 2-letter language code (e.g. `"en"`, `"zh"`).                          |
-// | `leagueID`    | string | no       | Filter by a specific league ID.                                        |
-// | `eventID`     | string | no       | Filter by a specific event ID.                                         |
-// | `isTopLeague` | string | no       | Limit to provider-flagged top leagues.                                 |
+// | Field         | Type   | Required | Allowed values / format                                                                              |
+// | ---           | ---    | ---      | ---                                                                                                  |
+// | `sportID`     | string | yes      | Sport ID — see "Sport IDs" below.                                                                    |
+// | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
+// | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures).                           |
+// | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
+// | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
+// | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |
+// | `leagueID`    | string | no       | Provider-assigned league ID (numeric string). Empty string `""` or omitted = no league filter.       |
+// | `eventID`     | string | no       | Provider-assigned event ID (numeric string). Empty string `""` or omitted = no event filter.         |
+// | `isTopLeague` | string | no       | `"true"` to return only provider-flagged top leagues; `"false"` or empty `""` = no top-league filter. |
 //
 // ## Sport IDs (subset; the provider's full list may change over time)
 //
@@ -8916,7 +8916,7 @@ type ListLiveEventsRequest struct {
 	// Filter payload forwarded as-is to the upstream aggregator. Field shape follows the provider's API
 	// (see the table in the message-level docs above).
 	//
-	// Example — pull up to 10 in-play basketball head-to-head events, in English:
+	// Example A — pull up to 10 in-play basketball head-to-head events, in English (no optional filters):
 	//
 	// ```json
 	//
@@ -8926,15 +8926,42 @@ type ListLiveEventsRequest struct {
 	//	  "eventType": "Fixture",
 	//	  "take": "10",
 	//	  "skip": "0",
-	//	  "locale": "en",
-	//	  "leagueID": "",
-	//	  "eventID": "",
-	//	  "isTopLeague": ""
+	//	  "locale": "en"
 	//	}
 	//
 	// ```
 	//
-	// An empty payload returns the aggregator's default event list.
+	// Example B — same query, but limited to top leagues only and second page of 20 results:
+	//
+	// ```json
+	//
+	//	{
+	//	  "sportID": "2",
+	//	  "isLive": "true",
+	//	  "eventType": "Fixture",
+	//	  "take": "20",
+	//	  "skip": "20",
+	//	  "locale": "en",
+	//	  "isTopLeague": "true"
+	//	}
+	//
+	// ```
+	//
+	// Example C — fetch a specific event (e.g. for refresh) by `eventID`:
+	//
+	// ```json
+	//
+	//	{
+	//	  "sportID": "1",
+	//	  "isLive": "false",
+	//	  "eventType": "Fixture",
+	//	  "take": "1",
+	//	  "skip": "0",
+	//	  "locale": "en",
+	//	  "eventID": "123456789"
+	//	}
+	//
+	// ```
 	RequestPayload *structpb.Struct `protobuf:"bytes,2,opt,name=request_payload,json=requestPayload,proto3" json:"request_payload,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache

--- a/game/service/v1/game.pb.go
+++ b/game/service/v1/game.pb.go
@@ -8894,7 +8894,7 @@ func (x *GetGameInfoResponse) GetGameInfo() *GameInfo {
 // | ---           | ---    | ---      | ---                                                                                                  |
 // | `sportID`     | string | yes      | Sport ID, or a comma-separated list of sport IDs (e.g. `"1"`, `"1,2,6,7"`) — see "Sport IDs" below.  |
 // | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
-// | `eventType`   | string | yes      | `"fixture"` (head-to-head match) or `"outright"` (championship / futures). Case-insensitive.         |
+// | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures). Case-insensitive.         |
 // | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
 // | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
 // | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |
@@ -8923,7 +8923,7 @@ type ListLiveEventsRequest struct {
 	//	{
 	//	  "sportID": "2",
 	//	  "isLive": "true",
-	//	  "eventType": "fixture",
+	//	  "eventType": "Fixture",
 	//	  "take": "10",
 	//	  "skip": "0",
 	//	  "locale": "en"
@@ -8938,7 +8938,7 @@ type ListLiveEventsRequest struct {
 	//	{
 	//	  "sportID": "2",
 	//	  "isLive": "true",
-	//	  "eventType": "fixture",
+	//	  "eventType": "Fixture",
 	//	  "take": "20",
 	//	  "skip": "20",
 	//	  "locale": "en",
@@ -8954,7 +8954,7 @@ type ListLiveEventsRequest struct {
 	//	{
 	//	  "sportID": "1",
 	//	  "isLive": "false",
-	//	  "eventType": "fixture",
+	//	  "eventType": "Fixture",
 	//	  "take": "1",
 	//	  "skip": "0",
 	//	  "locale": "en",
@@ -8970,7 +8970,7 @@ type ListLiveEventsRequest struct {
 	//	{
 	//	  "sportID": "1,2,6,7",
 	//	  "isLive": "false",
-	//	  "eventType": "fixture",
+	//	  "eventType": "Fixture",
 	//	  "take": "10",
 	//	  "skip": "0",
 	//	  "locale": "en",

--- a/game/service/v1/game.pb.go
+++ b/game/service/v1/game.pb.go
@@ -8963,12 +8963,12 @@ type ListLiveEventsRequest struct {
 	//
 	// ```
 	//
-	// Example D — multi-sport pre-match top-league widget (Soccer + Basketball + Tennis + Baseball):
+	// Example D — pre-match tennis top-league widget:
 	//
 	// ```json
 	//
 	//	{
-	//	  "sportID": "1,2,6,7",
+	//	  "sportID": "6",
 	//	  "isLive": "false",
 	//	  "eventType": "Fixture",
 	//	  "take": "10",

--- a/game/service/v1/game.pb.go
+++ b/game/service/v1/game.pb.go
@@ -8892,9 +8892,9 @@ func (x *GetGameInfoResponse) GetGameInfo() *GameInfo {
 //
 // | Field         | Type   | Required | Allowed values / format                                                                              |
 // | ---           | ---    | ---      | ---                                                                                                  |
-// | `sportID`     | string | yes      | Sport ID — see "Sport IDs" below.                                                                    |
+// | `sportID`     | string | yes      | Sport ID, or a comma-separated list of sport IDs (e.g. `"1"`, `"1,2,6,7"`) — see "Sport IDs" below.  |
 // | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
-// | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures).                           |
+// | `eventType`   | string | yes      | `"fixture"` (head-to-head match) or `"outright"` (championship / futures). Case-insensitive.         |
 // | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
 // | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
 // | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |
@@ -8923,7 +8923,7 @@ type ListLiveEventsRequest struct {
 	//	{
 	//	  "sportID": "2",
 	//	  "isLive": "true",
-	//	  "eventType": "Fixture",
+	//	  "eventType": "fixture",
 	//	  "take": "10",
 	//	  "skip": "0",
 	//	  "locale": "en"
@@ -8938,7 +8938,7 @@ type ListLiveEventsRequest struct {
 	//	{
 	//	  "sportID": "2",
 	//	  "isLive": "true",
-	//	  "eventType": "Fixture",
+	//	  "eventType": "fixture",
 	//	  "take": "20",
 	//	  "skip": "20",
 	//	  "locale": "en",
@@ -8954,11 +8954,27 @@ type ListLiveEventsRequest struct {
 	//	{
 	//	  "sportID": "1",
 	//	  "isLive": "false",
-	//	  "eventType": "Fixture",
+	//	  "eventType": "fixture",
 	//	  "take": "1",
 	//	  "skip": "0",
 	//	  "locale": "en",
 	//	  "eventID": "123456789"
+	//	}
+	//
+	// ```
+	//
+	// Example D — multi-sport pre-match top-league widget (Soccer + Basketball + Tennis + Baseball):
+	//
+	// ```json
+	//
+	//	{
+	//	  "sportID": "1,2,6,7",
+	//	  "isLive": "false",
+	//	  "eventType": "fixture",
+	//	  "take": "10",
+	//	  "skip": "0",
+	//	  "locale": "en",
+	//	  "isTopLeague": "true"
 	//	}
 	//
 	// ```

--- a/game/service/v1/game.proto
+++ b/game/service/v1/game.proto
@@ -1886,6 +1886,20 @@ message ListLiveEventsRequest {
 	//   "isTopLeague": "true"
 	// }
 	// ```
+	//
+	// Example E — list events for a specific league by `leagueID` (e.g. a league landing page):
+	//
+	// ```json
+	// {
+	//   "sportID": "1",
+	//   "isLive": "false",
+	//   "eventType": "Fixture",
+	//   "take": "20",
+	//   "skip": "0",
+	//   "locale": "en",
+	//   "leagueID": "2627"
+	// }
+	// ```
 	google.protobuf.Struct request_payload = 2;
 }
 

--- a/game/service/v1/game.proto
+++ b/game/service/v1/game.proto
@@ -91,6 +91,8 @@ service Game {
 		};
 	};
 
+	// List in-play events for a live-betting game by proxying to the upstream aggregator. Responses are cached for 30 seconds.
+	// See ListLiveEventsRequest for details.
 	rpc ListLiveEvents(ListLiveEventsRequest) returns (ListLiveEventsResponse) {
 		option (google.api.http) = {
 			post: "/v1/game/live-events/list"
@@ -1795,12 +1797,127 @@ message GetGameInfoResponse {
 	GameInfo game_info = 1;
 }
 
+// ListLiveEvents - list events (in-play and pre-match) of a sports/live-betting game by proxying
+// `request_payload` to the upstream aggregator's events endpoint.
+//
+// Behavior:
+// - The upstream endpoint and provider credentials are resolved from `game_id`.
+// - `request_payload` is forwarded as-is; the operator's API key/secret are used to sign the call.
+// - Responses are cached for 30 seconds keyed by `game_id` + payload hash and shared across operators.
+//
+// ## request_payload fields (forwarded verbatim to the provider)
+//
+// | Field         | Type   | Required | Description                                                            |
+// | ---           | ---    | ---      | ---                                                                    |
+// | `sportID`     | string | yes      | Sport ID filter — see "Sport IDs" below.                               |
+// | `isLive`      | string | yes      | `"true"` for in-play (live) events, `"false"` for pre-match (early).   |
+// | `eventType`   | string | yes      | `"Fixture"` (head-to-head) or `"Outright"` (championship/futures).     |
+// | `take`        | string | yes      | Page size — number of events to return.                                |
+// | `skip`        | string | yes      | Page offset — number of events to skip.                                |
+// | `locale`      | string | yes      | 2-letter language code (e.g. `"en"`, `"zh"`).                          |
+// | `leagueID`    | string | no       | Filter by a specific league ID.                                        |
+// | `eventID`     | string | no       | Filter by a specific event ID.                                         |
+// | `isTopLeague` | string | no       | Limit to provider-flagged top leagues.                                 |
+//
+// ## Sport IDs (subset; the provider's full list may change over time)
+//
+// `1` Soccer, `2` Basketball, `3` American Football, `6` Tennis, `7` Baseball, `8` Ice Hockey,
+// `10` Handball, `11` Rugby League, `12` Golf, `13` Snooker / Pool, `14` Motor Racing, `15` Darts,
+// `19` Volleyball, `20` Boxing, `25` Futsal, `26` Table Tennis, `34` Badminton, `35` Rugby Union,
+// `43` MMA, `59` Cricket, `61` Horse Racing, `64` E-Sports, `66` Greyhounds, `82` Muay Thai,
+// `136` Kabaddi, `220` LOL, `221` DOTA2, `228` Valorant, `229` KOG, `230` CS2.
 message ListLiveEventsRequest {
+	// Game ID identifying which live/sports product to query (used to resolve the upstream endpoint and credentials).
 	string game_id = 1;
+	// Filter payload forwarded as-is to the upstream aggregator. Field shape follows the provider's API
+	// (see the table in the message-level docs above).
+	//
+	// Example — pull up to 10 in-play basketball head-to-head events, in English:
+	//
+	// ```json
+	// {
+	//   "sportID": "2",
+	//   "isLive": "true",
+	//   "eventType": "Fixture",
+	//   "take": "10",
+	//   "skip": "0",
+	//   "locale": "en",
+	//   "leagueID": "",
+	//   "eventID": "",
+	//   "isTopLeague": ""
+	// }
+	// ```
+	//
+	// An empty payload returns the aggregator's default event list.
 	google.protobuf.Struct request_payload = 2;
 }
 
+// ListLiveEventsResponse - events returned by the upstream aggregator (passed through without schema enforcement).
+//
+// ## Common event fields (provider-defined)
+//
+// - `_id` — event ID.
+// - `IsLive` — whether the event is currently in-play.
+// - `IsSuspended` — whether the event is temporarily suspended.
+// - `IsTopLeague` — whether the event belongs to a provider-flagged top league (informational only).
+// - `LeagueId` / `MasterLeagueId` — league IDs (`MasterLeagueId` is stable across seasons; usable for league logo lookup).
+// - `SportId` — sport ID (see ListLiveEventsRequest).
+// - `StartEventDate` — scheduled start time.
+// - `Status` — event status enum: `0` NotStarted, `1` InProgress, `2` RaceOff, `3` Resulted, `4` Cancelled.
+// - `Type` — `"Fixture"` or `"Outright"`.
+// - `EventName` / `BetslipLine` / `SportName` / `LeagueName` / `regionCode` / `regionName` — display fields.
+// - `TotalActiveMarketsCount` — number of active markets on the event.
+// - `Participants[]` — `{_id, Name, VenueRole}` (team / player info; `VenueRole` indicates country or region).
+// - `Score` — `{HomeScore, AwayScore}` for in-play events.
+// - `Markets[]` — `{_id, Name, IsSuspended, LeagueId, StartDate, MarketType, Selections}`.
+//   - `MarketType` — `{_id, Name}` (e.g. handicap / over-under / moneyline).
+// - `Selections[]` — `{_id, BetslipLine, IsDisabled, Name, IsOption, TrueOdds, OutcomeType, Points, Status, DisplayOdds}`.
+//   - `IsOption` — whether this is the main handicap line or a derived (alternate) line.
+//   - `TrueOdds` — true odds in decimal (European) format.
+//   - `OutcomeType` — UI hint, e.g. `"Over"` / `"Under"`, `"Home"` / `"Away"` / `"Tie"`.
+//   - `Points` — handicap / line value for the selection.
+//   - `DisplayOdds` — `{Decimal, HK, Indo, Malay}`. `Decimal` is also the settlement format.
+//
+// On upstream errors, an entry may instead carry `errorMessage`, `errorCode`,
+// `errorMessages[].{message, parameterName, providedValue}`, and `sessionId` for support diagnostics.
 message ListLiveEventsResponse {
+	// Event objects passed through from the aggregator. See the message-level docs for the field schema.
+	//
+	// ```json
+	// [
+	//   {
+	//     "_id": "evt_12345",
+	//     "SportId": 2,
+	//     "LeagueName": "NBA",
+	//     "EventName": "Lakers vs Celtics",
+	//     "StartEventDate": "2026-04-26T20:00:00Z",
+	//     "Status": 1,
+	//     "Type": "Fixture",
+	//     "Participants": [
+	//       {"_id": "t_1", "Name": "Lakers", "VenueRole": "Home"},
+	//       {"_id": "t_2", "Name": "Celtics", "VenueRole": "Away"}
+	//     ],
+	//     "Score": {"HomeScore": 42, "AwayScore": 38},
+	//     "Markets": [
+	//       {
+	//         "_id": "mkt_1",
+	//         "Name": "Moneyline",
+	//         "MarketType": {"_id": "mt_ml", "Name": "Moneyline"},
+	//         "Selections": [
+	//           {
+	//             "_id": "sel_1",
+	//             "Name": "Lakers",
+	//             "OutcomeType": "Home",
+	//             "TrueOdds": 1.85,
+	//             "DisplayOdds": {"Decimal": "1.85", "HK": "0.85", "Indo": "-1.18", "Malay": "0.85"},
+	//             "Status": 1
+	//           }
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// ]
+	// ```
 	repeated google.protobuf.Struct events = 1;
 }
 

--- a/game/service/v1/game.proto
+++ b/game/service/v1/game.proto
@@ -1900,6 +1900,19 @@ message ListLiveEventsRequest {
 	//   "leagueID": "2627"
 	// }
 	// ```
+	//
+	// Example F — list outright (championship / futures) markets, e.g. a Soccer "winner" board:
+	//
+	// ```json
+	// {
+	//   "sportID": "1",
+	//   "isLive": "false",
+	//   "eventType": "Outright",
+	//   "take": "20",
+	//   "skip": "0",
+	//   "locale": "en"
+	// }
+	// ```
 	google.protobuf.Struct request_payload = 2;
 }
 

--- a/game/service/v1/game.proto
+++ b/game/service/v1/game.proto
@@ -1809,9 +1809,9 @@ message GetGameInfoResponse {
 //
 // | Field         | Type   | Required | Allowed values / format                                                                              |
 // | ---           | ---    | ---      | ---                                                                                                  |
-// | `sportID`     | string | yes      | Sport ID — see "Sport IDs" below.                                                                    |
+// | `sportID`     | string | yes      | Sport ID, or a comma-separated list of sport IDs (e.g. `"1"`, `"1,2,6,7"`) — see "Sport IDs" below.  |
 // | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
-// | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures).                           |
+// | `eventType`   | string | yes      | `"fixture"` (head-to-head match) or `"outright"` (championship / futures). Case-insensitive.         |
 // | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
 // | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
 // | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |
@@ -1838,7 +1838,7 @@ message ListLiveEventsRequest {
 	// {
 	//   "sportID": "2",
 	//   "isLive": "true",
-	//   "eventType": "Fixture",
+	//   "eventType": "fixture",
 	//   "take": "10",
 	//   "skip": "0",
 	//   "locale": "en"
@@ -1851,7 +1851,7 @@ message ListLiveEventsRequest {
 	// {
 	//   "sportID": "2",
 	//   "isLive": "true",
-	//   "eventType": "Fixture",
+	//   "eventType": "fixture",
 	//   "take": "20",
 	//   "skip": "20",
 	//   "locale": "en",
@@ -1865,11 +1865,25 @@ message ListLiveEventsRequest {
 	// {
 	//   "sportID": "1",
 	//   "isLive": "false",
-	//   "eventType": "Fixture",
+	//   "eventType": "fixture",
 	//   "take": "1",
 	//   "skip": "0",
 	//   "locale": "en",
 	//   "eventID": "123456789"
+	// }
+	// ```
+	//
+	// Example D — multi-sport pre-match top-league widget (Soccer + Basketball + Tennis + Baseball):
+	//
+	// ```json
+	// {
+	//   "sportID": "1,2,6,7",
+	//   "isLive": "false",
+	//   "eventType": "fixture",
+	//   "take": "10",
+	//   "skip": "0",
+	//   "locale": "en",
+	//   "isTopLeague": "true"
 	// }
 	// ```
 	google.protobuf.Struct request_payload = 2;

--- a/game/service/v1/game.proto
+++ b/game/service/v1/game.proto
@@ -1807,17 +1807,17 @@ message GetGameInfoResponse {
 //
 // ## request_payload fields (forwarded verbatim to the provider)
 //
-// | Field         | Type   | Required | Description                                                            |
-// | ---           | ---    | ---      | ---                                                                    |
-// | `sportID`     | string | yes      | Sport ID filter — see "Sport IDs" below.                               |
-// | `isLive`      | string | yes      | `"true"` for in-play (live) events, `"false"` for pre-match (early).   |
-// | `eventType`   | string | yes      | `"Fixture"` (head-to-head) or `"Outright"` (championship/futures).     |
-// | `take`        | string | yes      | Page size — number of events to return.                                |
-// | `skip`        | string | yes      | Page offset — number of events to skip.                                |
-// | `locale`      | string | yes      | 2-letter language code (e.g. `"en"`, `"zh"`).                          |
-// | `leagueID`    | string | no       | Filter by a specific league ID.                                        |
-// | `eventID`     | string | no       | Filter by a specific event ID.                                         |
-// | `isTopLeague` | string | no       | Limit to provider-flagged top leagues.                                 |
+// | Field         | Type   | Required | Allowed values / format                                                                              |
+// | ---           | ---    | ---      | ---                                                                                                  |
+// | `sportID`     | string | yes      | Sport ID — see "Sport IDs" below.                                                                    |
+// | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
+// | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures).                           |
+// | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
+// | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
+// | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |
+// | `leagueID`    | string | no       | Provider-assigned league ID (numeric string). Empty string `""` or omitted = no league filter.       |
+// | `eventID`     | string | no       | Provider-assigned event ID (numeric string). Empty string `""` or omitted = no event filter.         |
+// | `isTopLeague` | string | no       | `"true"` to return only provider-flagged top leagues; `"false"` or empty `""` = no top-league filter. |
 //
 // ## Sport IDs (subset; the provider's full list may change over time)
 //
@@ -1832,7 +1832,7 @@ message ListLiveEventsRequest {
 	// Filter payload forwarded as-is to the upstream aggregator. Field shape follows the provider's API
 	// (see the table in the message-level docs above).
 	//
-	// Example — pull up to 10 in-play basketball head-to-head events, in English:
+	// Example A — pull up to 10 in-play basketball head-to-head events, in English (no optional filters):
 	//
 	// ```json
 	// {
@@ -1841,14 +1841,37 @@ message ListLiveEventsRequest {
 	//   "eventType": "Fixture",
 	//   "take": "10",
 	//   "skip": "0",
-	//   "locale": "en",
-	//   "leagueID": "",
-	//   "eventID": "",
-	//   "isTopLeague": ""
+	//   "locale": "en"
 	// }
 	// ```
 	//
-	// An empty payload returns the aggregator's default event list.
+	// Example B — same query, but limited to top leagues only and second page of 20 results:
+	//
+	// ```json
+	// {
+	//   "sportID": "2",
+	//   "isLive": "true",
+	//   "eventType": "Fixture",
+	//   "take": "20",
+	//   "skip": "20",
+	//   "locale": "en",
+	//   "isTopLeague": "true"
+	// }
+	// ```
+	//
+	// Example C — fetch a specific event (e.g. for refresh) by `eventID`:
+	//
+	// ```json
+	// {
+	//   "sportID": "1",
+	//   "isLive": "false",
+	//   "eventType": "Fixture",
+	//   "take": "1",
+	//   "skip": "0",
+	//   "locale": "en",
+	//   "eventID": "123456789"
+	// }
+	// ```
 	google.protobuf.Struct request_payload = 2;
 }
 

--- a/game/service/v1/game.proto
+++ b/game/service/v1/game.proto
@@ -1811,7 +1811,7 @@ message GetGameInfoResponse {
 // | ---           | ---    | ---      | ---                                                                                                  |
 // | `sportID`     | string | yes      | Sport ID, or a comma-separated list of sport IDs (e.g. `"1"`, `"1,2,6,7"`) — see "Sport IDs" below.  |
 // | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
-// | `eventType`   | string | yes      | `"fixture"` (head-to-head match) or `"outright"` (championship / futures). Case-insensitive.         |
+// | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures). Case-insensitive.         |
 // | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
 // | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
 // | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |
@@ -1838,7 +1838,7 @@ message ListLiveEventsRequest {
 	// {
 	//   "sportID": "2",
 	//   "isLive": "true",
-	//   "eventType": "fixture",
+	//   "eventType": "Fixture",
 	//   "take": "10",
 	//   "skip": "0",
 	//   "locale": "en"
@@ -1851,7 +1851,7 @@ message ListLiveEventsRequest {
 	// {
 	//   "sportID": "2",
 	//   "isLive": "true",
-	//   "eventType": "fixture",
+	//   "eventType": "Fixture",
 	//   "take": "20",
 	//   "skip": "20",
 	//   "locale": "en",
@@ -1865,7 +1865,7 @@ message ListLiveEventsRequest {
 	// {
 	//   "sportID": "1",
 	//   "isLive": "false",
-	//   "eventType": "fixture",
+	//   "eventType": "Fixture",
 	//   "take": "1",
 	//   "skip": "0",
 	//   "locale": "en",
@@ -1879,7 +1879,7 @@ message ListLiveEventsRequest {
 	// {
 	//   "sportID": "1,2,6,7",
 	//   "isLive": "false",
-	//   "eventType": "fixture",
+	//   "eventType": "Fixture",
 	//   "take": "10",
 	//   "skip": "0",
 	//   "locale": "en",

--- a/game/service/v1/game.proto
+++ b/game/service/v1/game.proto
@@ -1873,11 +1873,11 @@ message ListLiveEventsRequest {
 	// }
 	// ```
 	//
-	// Example D — multi-sport pre-match top-league widget (Soccer + Basketball + Tennis + Baseball):
+	// Example D — pre-match tennis top-league widget:
 	//
 	// ```json
 	// {
-	//   "sportID": "1,2,6,7",
+	//   "sportID": "6",
 	//   "isLive": "false",
 	//   "eventType": "Fixture",
 	//   "take": "10",

--- a/game/service/v1/game_grpc.pb.go
+++ b/game/service/v1/game_grpc.pb.go
@@ -131,6 +131,8 @@ type GameClient interface {
 	Play(ctx context.Context, in *PlayRequest, opts ...grpc.CallOption) (*PlayResponse, error)
 	Rollback(ctx context.Context, in *RollbackRequest, opts ...grpc.CallOption) (*RollbackResponse, error)
 	ListBets(ctx context.Context, in *ListBetsRequest, opts ...grpc.CallOption) (*ListBetsResponse, error)
+	// List in-play events for a live-betting game by proxying to the upstream aggregator. Responses are cached for 30 seconds.
+	// See ListLiveEventsRequest for details.
 	ListLiveEvents(ctx context.Context, in *ListLiveEventsRequest, opts ...grpc.CallOption) (*ListLiveEventsResponse, error)
 	ExportBets(ctx context.Context, in *ExportBetsRequest, opts ...grpc.CallOption) (*ExportBetsResponse, error)
 	BackofficeListGames(ctx context.Context, in *BackofficeListGamesRequest, opts ...grpc.CallOption) (*BackofficeListGamesResponse, error)
@@ -1160,6 +1162,8 @@ type GameServer interface {
 	Play(context.Context, *PlayRequest) (*PlayResponse, error)
 	Rollback(context.Context, *RollbackRequest) (*RollbackResponse, error)
 	ListBets(context.Context, *ListBetsRequest) (*ListBetsResponse, error)
+	// List in-play events for a live-betting game by proxying to the upstream aggregator. Responses are cached for 30 seconds.
+	// See ListLiveEventsRequest for details.
 	ListLiveEvents(context.Context, *ListLiveEventsRequest) (*ListLiveEventsResponse, error)
 	ExportBets(context.Context, *ExportBetsRequest) (*ExportBetsResponse, error)
 	BackofficeListGames(context.Context, *BackofficeListGamesRequest) (*BackofficeListGamesResponse, error)

--- a/game/service/v1/game_http.pb.go
+++ b/game/service/v1/game_http.pb.go
@@ -44,6 +44,8 @@ type GameHTTPServer interface {
 	ListBets(context.Context, *ListBetsRequest) (*ListBetsResponse, error)
 	ListCategories(context.Context, *ListCategoriesRequest) (*ListCategoriesResponse, error)
 	ListGames(context.Context, *ListGamesRequest) (*ListGamesResponse, error)
+	// ListLiveEvents List in-play events for a live-betting game by proxying to the upstream aggregator. Responses are cached for 30 seconds.
+	// See ListLiveEventsRequest for details.
 	ListLiveEvents(context.Context, *ListLiveEventsRequest) (*ListLiveEventsResponse, error)
 	ListProviders(context.Context, *ListProvidersRequest) (*ListProvidersResponse, error)
 	Play(context.Context, *PlayRequest) (*PlayResponse, error)
@@ -364,6 +366,8 @@ type GameHTTPClient interface {
 	ListBets(ctx context.Context, req *ListBetsRequest, opts ...http.CallOption) (rsp *ListBetsResponse, err error)
 	ListCategories(ctx context.Context, req *ListCategoriesRequest, opts ...http.CallOption) (rsp *ListCategoriesResponse, err error)
 	ListGames(ctx context.Context, req *ListGamesRequest, opts ...http.CallOption) (rsp *ListGamesResponse, err error)
+	// ListLiveEvents List in-play events for a live-betting game by proxying to the upstream aggregator. Responses are cached for 30 seconds.
+	// See ListLiveEventsRequest for details.
 	ListLiveEvents(ctx context.Context, req *ListLiveEventsRequest, opts ...http.CallOption) (rsp *ListLiveEventsResponse, err error)
 	ListProviders(ctx context.Context, req *ListProvidersRequest, opts ...http.CallOption) (rsp *ListProvidersResponse, err error)
 	Play(ctx context.Context, req *PlayRequest, opts ...http.CallOption) (rsp *PlayResponse, err error)
@@ -496,6 +500,8 @@ func (c *GameHTTPClientImpl) ListGames(ctx context.Context, in *ListGamesRequest
 	return &out, nil
 }
 
+// ListLiveEvents List in-play events for a live-betting game by proxying to the upstream aggregator. Responses are cached for 30 seconds.
+// See ListLiveEventsRequest for details.
 func (c *GameHTTPClientImpl) ListLiveEvents(ctx context.Context, in *ListLiveEventsRequest, opts ...http.CallOption) (*ListLiveEventsResponse, error) {
 	var out ListLiveEventsResponse
 	pattern := "/v1/game/live-events/list"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29151,11 +29151,11 @@ components:
                          }
                          ```
 
-                         Example D — multi-sport pre-match top-league widget (Soccer + Basketball + Tennis + Baseball):
+                         Example D — pre-match tennis top-league widget:
 
                          ```json
                          {
-                           "sportID": "1,2,6,7",
+                           "sportID": "6",
                            "isLive": "false",
                            "eventType": "Fixture",
                            "take": "10",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29116,7 +29116,7 @@ components:
                          {
                            "sportID": "2",
                            "isLive": "true",
-                           "eventType": "fixture",
+                           "eventType": "Fixture",
                            "take": "10",
                            "skip": "0",
                            "locale": "en"
@@ -29129,7 +29129,7 @@ components:
                          {
                            "sportID": "2",
                            "isLive": "true",
-                           "eventType": "fixture",
+                           "eventType": "Fixture",
                            "take": "20",
                            "skip": "20",
                            "locale": "en",
@@ -29143,7 +29143,7 @@ components:
                          {
                            "sportID": "1",
                            "isLive": "false",
-                           "eventType": "fixture",
+                           "eventType": "Fixture",
                            "take": "1",
                            "skip": "0",
                            "locale": "en",
@@ -29157,7 +29157,7 @@ components:
                          {
                            "sportID": "1,2,6,7",
                            "isLive": "false",
-                           "eventType": "fixture",
+                           "eventType": "Fixture",
                            "take": "10",
                            "skip": "0",
                            "locale": "en",
@@ -29179,7 +29179,7 @@ components:
                  | ---           | ---    | ---      | ---                                                                                                  |
                  | `sportID`     | string | yes      | Sport ID, or a comma-separated list of sport IDs (e.g. `"1"`, `"1,2,6,7"`) — see "Sport IDs" below.  |
                  | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
-                 | `eventType`   | string | yes      | `"fixture"` (head-to-head match) or `"outright"` (championship / futures). Case-insensitive.         |
+                 | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures). Case-insensitive.         |
                  | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
                  | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
                  | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29178,6 +29178,19 @@ components:
                            "leagueID": "2627"
                          }
                          ```
+
+                         Example F — list outright (championship / futures) markets, e.g. a Soccer "winner" board:
+
+                         ```json
+                         {
+                           "sportID": "1",
+                           "isLive": "false",
+                           "eventType": "Outright",
+                           "take": "20",
+                           "skip": "0",
+                           "locale": "en"
+                         }
+                         ```
             description: |-
                 ListLiveEvents - list events (in-play and pre-match) of a sports/live-betting game by proxying
                  `request_payload` to the upstream aggregator's events endpoint.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9739,6 +9739,9 @@ paths:
         post:
             tags:
                 - Game
+            description: |-
+                List in-play events for a live-betting game by proxying to the upstream aggregator. Responses are cached for 30 seconds.
+                 See ListLiveEventsRequest for details.
             operationId: Game_ListLiveEvents
             requestBody:
                 content:
@@ -29100,8 +29103,60 @@ components:
             properties:
                 gameId:
                     type: string
+                    description: Game ID identifying which live/sports product to query (used to resolve the upstream endpoint and credentials).
                 requestPayload:
                     type: object
+                    description: |-
+                        Filter payload forwarded as-is to the upstream aggregator. Field shape follows the provider's API
+                         (see the table in the message-level docs above).
+
+                         Example — pull up to 10 in-play basketball head-to-head events, in English:
+
+                         ```json
+                         {
+                           "sportID": "2",
+                           "isLive": "true",
+                           "eventType": "Fixture",
+                           "take": "10",
+                           "skip": "0",
+                           "locale": "en",
+                           "leagueID": "",
+                           "eventID": "",
+                           "isTopLeague": ""
+                         }
+                         ```
+
+                         An empty payload returns the aggregator's default event list.
+            description: |-
+                ListLiveEvents - list events (in-play and pre-match) of a sports/live-betting game by proxying
+                 `request_payload` to the upstream aggregator's events endpoint.
+
+                 Behavior:
+                 - The upstream endpoint and provider credentials are resolved from `game_id`.
+                 - `request_payload` is forwarded as-is; the operator's API key/secret are used to sign the call.
+                 - Responses are cached for 30 seconds keyed by `game_id` + payload hash and shared across operators.
+
+                 ## request_payload fields (forwarded verbatim to the provider)
+
+                 | Field         | Type   | Required | Description                                                            |
+                 | ---           | ---    | ---      | ---                                                                    |
+                 | `sportID`     | string | yes      | Sport ID filter — see "Sport IDs" below.                               |
+                 | `isLive`      | string | yes      | `"true"` for in-play (live) events, `"false"` for pre-match (early).   |
+                 | `eventType`   | string | yes      | `"Fixture"` (head-to-head) or `"Outright"` (championship/futures).     |
+                 | `take`        | string | yes      | Page size — number of events to return.                                |
+                 | `skip`        | string | yes      | Page offset — number of events to skip.                                |
+                 | `locale`      | string | yes      | 2-letter language code (e.g. `"en"`, `"zh"`).                          |
+                 | `leagueID`    | string | no       | Filter by a specific league ID.                                        |
+                 | `eventID`     | string | no       | Filter by a specific event ID.                                         |
+                 | `isTopLeague` | string | no       | Limit to provider-flagged top leagues.                                 |
+
+                 ## Sport IDs (subset; the provider's full list may change over time)
+
+                 `1` Soccer, `2` Basketball, `3` American Football, `6` Tennis, `7` Baseball, `8` Ice Hockey,
+                 `10` Handball, `11` Rugby League, `12` Golf, `13` Snooker / Pool, `14` Motor Racing, `15` Darts,
+                 `19` Volleyball, `20` Boxing, `25` Futsal, `26` Table Tennis, `34` Badminton, `35` Rugby Union,
+                 `43` MMA, `59` Cricket, `61` Horse Racing, `64` E-Sports, `66` Greyhounds, `82` Muay Thai,
+                 `136` Kabaddi, `220` LOL, `221` DOTA2, `228` Valorant, `229` KOG, `230` CS2.
         api.game.service.v1.ListLiveEventsResponse:
             type: object
             properties:
@@ -29109,6 +29164,73 @@ components:
                     type: array
                     items:
                         type: object
+                    description: |-
+                        Event objects passed through from the aggregator. See the message-level docs for the field schema.
+
+                         ```json
+                         [
+                           {
+                             "_id": "evt_12345",
+                             "SportId": 2,
+                             "LeagueName": "NBA",
+                             "EventName": "Lakers vs Celtics",
+                             "StartEventDate": "2026-04-26T20:00:00Z",
+                             "Status": 1,
+                             "Type": "Fixture",
+                             "Participants": [
+                               {"_id": "t_1", "Name": "Lakers", "VenueRole": "Home"},
+                               {"_id": "t_2", "Name": "Celtics", "VenueRole": "Away"}
+                             ],
+                             "Score": {"HomeScore": 42, "AwayScore": 38},
+                             "Markets": [
+                               {
+                                 "_id": "mkt_1",
+                                 "Name": "Moneyline",
+                                 "MarketType": {"_id": "mt_ml", "Name": "Moneyline"},
+                                 "Selections": [
+                                   {
+                                     "_id": "sel_1",
+                                     "Name": "Lakers",
+                                     "OutcomeType": "Home",
+                                     "TrueOdds": 1.85,
+                                     "DisplayOdds": {"Decimal": "1.85", "HK": "0.85", "Indo": "-1.18", "Malay": "0.85"},
+                                     "Status": 1
+                                   }
+                                 ]
+                               }
+                             ]
+                           }
+                         ]
+                         ```
+            description: |-
+                ListLiveEventsResponse - events returned by the upstream aggregator (passed through without schema enforcement).
+
+                 ## Common event fields (provider-defined)
+
+                 - `_id` — event ID.
+                 - `IsLive` — whether the event is currently in-play.
+                 - `IsSuspended` — whether the event is temporarily suspended.
+                 - `IsTopLeague` — whether the event belongs to a provider-flagged top league (informational only).
+                 - `LeagueId` / `MasterLeagueId` — league IDs (`MasterLeagueId` is stable across seasons; usable for league logo lookup).
+                 - `SportId` — sport ID (see ListLiveEventsRequest).
+                 - `StartEventDate` — scheduled start time.
+                 - `Status` — event status enum: `0` NotStarted, `1` InProgress, `2` RaceOff, `3` Resulted, `4` Cancelled.
+                 - `Type` — `"Fixture"` or `"Outright"`.
+                 - `EventName` / `BetslipLine` / `SportName` / `LeagueName` / `regionCode` / `regionName` — display fields.
+                 - `TotalActiveMarketsCount` — number of active markets on the event.
+                 - `Participants[]` — `{_id, Name, VenueRole}` (team / player info; `VenueRole` indicates country or region).
+                 - `Score` — `{HomeScore, AwayScore}` for in-play events.
+                 - `Markets[]` — `{_id, Name, IsSuspended, LeagueId, StartDate, MarketType, Selections}`.
+                   - `MarketType` — `{_id, Name}` (e.g. handicap / over-under / moneyline).
+                 - `Selections[]` — `{_id, BetslipLine, IsDisabled, Name, IsOption, TrueOdds, OutcomeType, Points, Status, DisplayOdds}`.
+                   - `IsOption` — whether this is the main handicap line or a derived (alternate) line.
+                   - `TrueOdds` — true odds in decimal (European) format.
+                   - `OutcomeType` — UI hint, e.g. `"Over"` / `"Under"`, `"Home"` / `"Away"` / `"Tie"`.
+                   - `Points` — handicap / line value for the selection.
+                   - `DisplayOdds` — `{Decimal, HK, Indo, Malay}`. `Decimal` is also the settlement format.
+
+                 On upstream errors, an entry may instead carry `errorMessage`, `errorCode`,
+                 `errorMessages[].{message, parameterName, providedValue}`, and `sessionId` for support diagnostics.
         api.game.service.v1.ListMultipleBetsResponse:
             type: object
             properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29164,6 +29164,20 @@ components:
                            "isTopLeague": "true"
                          }
                          ```
+
+                         Example E — list events for a specific league by `leagueID` (e.g. a league landing page):
+
+                         ```json
+                         {
+                           "sportID": "1",
+                           "isLive": "false",
+                           "eventType": "Fixture",
+                           "take": "20",
+                           "skip": "0",
+                           "locale": "en",
+                           "leagueID": "2627"
+                         }
+                         ```
             description: |-
                 ListLiveEvents - list events (in-play and pre-match) of a sports/live-betting game by proxying
                  `request_payload` to the upstream aggregator's events endpoint.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29116,7 +29116,7 @@ components:
                          {
                            "sportID": "2",
                            "isLive": "true",
-                           "eventType": "Fixture",
+                           "eventType": "fixture",
                            "take": "10",
                            "skip": "0",
                            "locale": "en"
@@ -29129,7 +29129,7 @@ components:
                          {
                            "sportID": "2",
                            "isLive": "true",
-                           "eventType": "Fixture",
+                           "eventType": "fixture",
                            "take": "20",
                            "skip": "20",
                            "locale": "en",
@@ -29143,11 +29143,25 @@ components:
                          {
                            "sportID": "1",
                            "isLive": "false",
-                           "eventType": "Fixture",
+                           "eventType": "fixture",
                            "take": "1",
                            "skip": "0",
                            "locale": "en",
                            "eventID": "123456789"
+                         }
+                         ```
+
+                         Example D — multi-sport pre-match top-league widget (Soccer + Basketball + Tennis + Baseball):
+
+                         ```json
+                         {
+                           "sportID": "1,2,6,7",
+                           "isLive": "false",
+                           "eventType": "fixture",
+                           "take": "10",
+                           "skip": "0",
+                           "locale": "en",
+                           "isTopLeague": "true"
                          }
                          ```
             description: |-
@@ -29163,9 +29177,9 @@ components:
 
                  | Field         | Type   | Required | Allowed values / format                                                                              |
                  | ---           | ---    | ---      | ---                                                                                                  |
-                 | `sportID`     | string | yes      | Sport ID — see "Sport IDs" below.                                                                    |
+                 | `sportID`     | string | yes      | Sport ID, or a comma-separated list of sport IDs (e.g. `"1"`, `"1,2,6,7"`) — see "Sport IDs" below.  |
                  | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
-                 | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures).                           |
+                 | `eventType`   | string | yes      | `"fixture"` (head-to-head match) or `"outright"` (championship / futures). Case-insensitive.         |
                  | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
                  | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
                  | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29110,7 +29110,7 @@ components:
                         Filter payload forwarded as-is to the upstream aggregator. Field shape follows the provider's API
                          (see the table in the message-level docs above).
 
-                         Example — pull up to 10 in-play basketball head-to-head events, in English:
+                         Example A — pull up to 10 in-play basketball head-to-head events, in English (no optional filters):
 
                          ```json
                          {
@@ -29119,14 +29119,37 @@ components:
                            "eventType": "Fixture",
                            "take": "10",
                            "skip": "0",
-                           "locale": "en",
-                           "leagueID": "",
-                           "eventID": "",
-                           "isTopLeague": ""
+                           "locale": "en"
                          }
                          ```
 
-                         An empty payload returns the aggregator's default event list.
+                         Example B — same query, but limited to top leagues only and second page of 20 results:
+
+                         ```json
+                         {
+                           "sportID": "2",
+                           "isLive": "true",
+                           "eventType": "Fixture",
+                           "take": "20",
+                           "skip": "20",
+                           "locale": "en",
+                           "isTopLeague": "true"
+                         }
+                         ```
+
+                         Example C — fetch a specific event (e.g. for refresh) by `eventID`:
+
+                         ```json
+                         {
+                           "sportID": "1",
+                           "isLive": "false",
+                           "eventType": "Fixture",
+                           "take": "1",
+                           "skip": "0",
+                           "locale": "en",
+                           "eventID": "123456789"
+                         }
+                         ```
             description: |-
                 ListLiveEvents - list events (in-play and pre-match) of a sports/live-betting game by proxying
                  `request_payload` to the upstream aggregator's events endpoint.
@@ -29138,17 +29161,17 @@ components:
 
                  ## request_payload fields (forwarded verbatim to the provider)
 
-                 | Field         | Type   | Required | Description                                                            |
-                 | ---           | ---    | ---      | ---                                                                    |
-                 | `sportID`     | string | yes      | Sport ID filter — see "Sport IDs" below.                               |
-                 | `isLive`      | string | yes      | `"true"` for in-play (live) events, `"false"` for pre-match (early).   |
-                 | `eventType`   | string | yes      | `"Fixture"` (head-to-head) or `"Outright"` (championship/futures).     |
-                 | `take`        | string | yes      | Page size — number of events to return.                                |
-                 | `skip`        | string | yes      | Page offset — number of events to skip.                                |
-                 | `locale`      | string | yes      | 2-letter language code (e.g. `"en"`, `"zh"`).                          |
-                 | `leagueID`    | string | no       | Filter by a specific league ID.                                        |
-                 | `eventID`     | string | no       | Filter by a specific event ID.                                         |
-                 | `isTopLeague` | string | no       | Limit to provider-flagged top leagues.                                 |
+                 | Field         | Type   | Required | Allowed values / format                                                                              |
+                 | ---           | ---    | ---      | ---                                                                                                  |
+                 | `sportID`     | string | yes      | Sport ID — see "Sport IDs" below.                                                                    |
+                 | `isLive`      | string | yes      | `"true"` (in-play / live) or `"false"` (pre-match / early).                                          |
+                 | `eventType`   | string | yes      | `"Fixture"` (head-to-head match) or `"Outright"` (championship / futures).                           |
+                 | `take`        | string | yes      | Page size — positive integer as a string, e.g. `"10"`, `"50"`.                                       |
+                 | `skip`        | string | yes      | Page offset — non-negative integer as a string, e.g. `"0"`, `"20"`.                                  |
+                 | `locale`      | string | yes      | 2-letter language code, e.g. `"en"`, `"zh"`, `"ja"`, `"ko"`, `"th"`, `"vi"`, `"pt"`, `"es"`.         |
+                 | `leagueID`    | string | no       | Provider-assigned league ID (numeric string). Empty string `""` or omitted = no league filter.       |
+                 | `eventID`     | string | no       | Provider-assigned event ID (numeric string). Empty string `""` or omitted = no event filter.         |
+                 | `isTopLeague` | string | no       | `"true"` to return only provider-flagged top leagues; `"false"` or empty `""` = no top-league filter. |
 
                  ## Sport IDs (subset; the provider's full list may change over time)
 


### PR DESCRIPTION
## Summary
- Expand proto-level documentation for `ListLiveEvents` in `game/service/v1/game.proto` to match the CRM API doc style (e.g. `BackofficeCampaign_TriggerCrmCampaign`).
- Document the `request_payload` schema forwarded to the upstream aggregator: `sportID`, `isLive`, `eventType`, `take`, `skip`, `locale`, plus optional `leagueID`/`eventID`/`isTopLeague` — sourced from the provider's API doc.
- Add a quick sport-ID reference (`1` Soccer, `2` Basketball, `64` E-Sports, …) sourced from the provider's sports code list.
- Document the response event/market/selection schema (`Status` enum, `Type`, `Participants`, `Score`, `Markets`, `Selections`, `DisplayOdds`, error fallbacks) with a realistic JSON example.
- Regenerate `game.pb.go`, `game_grpc.pb.go`, `game_http.pb.go`, and `openapi.yaml` so the new comments propagate to clients and the OpenAPI surface.

Documentation-only change — no behavior or wire format changes.

## Test plan
- [x] `git diff` shows only doc-comment additions in the proto and corresponding regenerated stubs.
- [x] OpenAPI surface reflects the new `description` blocks under `Game_ListLiveEvents` and the request schema.
- [ ] Reviewer spot-checks rendered Swagger / Redoc to confirm the table and JSON examples render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)