### PR TITLE
fix(proto): correct copy-paste java_package mismatches in vip + system_event

### DIFF
--- a/system/service/v1/system_event.pb.go
+++ b/system/service/v1/system_event.pb.go
@@ -130,8 +130,8 @@ const file_system_service_v1_system_event_proto_rawDesc = "" +
 	"message_id\x18\x03 \x01(\tR\tmessageId\"\x0f\n" +
 	"\rEventResponse2c\n" +
 	"\vSystemEvent\x12T\n" +
-	"\x05Event\x12#.api.system.service.v1.EventRequest\x1a$.api.system.service.v1.EventResponse\"\x00B\\\n" +
-	"\x1eapi.system.image.pngservice.v1P\x01Z8github.com/infigaming-com/meepo-api/system/service/v1;v1b\x06proto3"
+	"\x05Event\x12#.api.system.service.v1.EventRequest\x1a$.api.system.service.v1.EventResponse\"\x00BS\n" +
+	"\x15api.system.service.v1P\x01Z8github.com/infigaming-com/meepo-api/system/service/v1;v1b\x06proto3"
 
 var (
 	file_system_service_v1_system_event_proto_rawDescOnce sync.Once

--- a/system/service/v1/system_event.proto
+++ b/system/service/v1/system_event.proto
@@ -4,7 +4,7 @@ package api.system.service.v1;
 
 option go_package = "github.com/infigaming-com/meepo-api/system/service/v1;v1";
 option java_multiple_files = true;
-option java_package = "api.system.image.pngservice.v1";
+option java_package = "api.system.service.v1";
 
 service SystemEvent {
     rpc Event(EventRequest) returns (EventResponse) {}

--- a/vip/service/v1/error_reason.pb.go
+++ b/vip/service/v1/error_reason.pb.go
@@ -83,8 +83,8 @@ const file_vip_service_v1_error_reason_proto_rawDesc = "" +
 	"\x14BONUS_CLAIM_REJECTED\x10\x91\xb0\n" +
 	"\x1a\x04\xa8E\x93\x03\x12\x1f\n" +
 	"\x13NO_CLAIMABLE_REWARD\x10\x92\xb0\n" +
-	"\x1a\x04\xa8E\x94\x03\x1a\x04\xa0E\xf4\x03BP\n" +
-	"\x15api.wallet.service.v1P\x01Z5github.com/infigaming-com/meepo-api/vip/service/v1;v1b\x06proto3"
+	"\x1a\x04\xa8E\x94\x03\x1a\x04\xa0E\xf4\x03BM\n" +
+	"\x12api.vip.service.v1P\x01Z5github.com/infigaming-com/meepo-api/vip/service/v1;v1b\x06proto3"
 
 var (
 	file_vip_service_v1_error_reason_proto_rawDescOnce sync.Once

--- a/vip/service/v1/error_reason.proto
+++ b/vip/service/v1/error_reason.proto
@@ -5,7 +5,7 @@ package api.vip.service.v1;
 import "errors/errors.proto";
 option go_package = "github.com/infigaming-com/meepo-api/vip/service/v1;v1";
 option java_multiple_files = true;
-option java_package = "api.wallet.service.v1";
+option java_package = "api.vip.service.v1";
 
 enum ErrorReason {
   option (errors.default_code) = 500;


### PR DESCRIPTION
## Summary

Repo-wide scan after PR #1322 review found 2 `java_package` copy-paste leaks. Both fixed here.

| File | Was | Now |
|---|---|---|
| `vip/service/v1/error_reason.proto` | `api.wallet.service.v1` | `api.vip.service.v1` |
| `system/service/v1/system_event.proto` | `api.system.image.pngservice.v1` | `api.system.service.v1` |

Both values were baked into the FileDescriptor binary inside the generated pb.go (`\x15api.wallet.service.v1P` and `\x1eapi.system.image.pngservice.v1P`), so any Java SDK consumer would have generated VIP classes into wallet's namespace and system_event into a non-existent png-service namespace.

**Scope of search**: ran a comparator over every non-third-party `.proto` checking `option java_package` against the file's own `package` directive. Only these two had a true mismatch. A few files have `package` directives missing the `api.` prefix (`payment/service/v1/payment.proto`, `idgen/service/v1/idgen.proto`, `system/service/v1/system.proto`) — those are internally consistent (java matches their own package) and changing them would be breaking, so left alone.

## Risk

Go side unaffected — uses `go_package`. `find -name "*.java"` returns empty across the entire repo, so no Java consumer exists yet — this is a forward-fix before anyone plugs Java into the build.

## Test plan

- [x] `make api` regenerates pb files cleanly
- [x] `go build ./...` clean
- [x] Descriptor binary verified: `vip/service/v1/error_reason.pb.go` now contains `\x12api.vip.service.v1P`; `system/service/v1/system_event.pb.go` now contains `\x15api.system.service.v1P`

🤖 Generated with [Claude Code](https://claude.com/claude-code)